### PR TITLE
feat(config-hub): implement Watcher — CONF-003 propagation watcher

### DIFF
--- a/packages/config-hub/src/__tests__/index.test.ts
+++ b/packages/config-hub/src/__tests__/index.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { aiderAdapter } from "@laup/aider";
 import { claudeCodeAdapter } from "@laup/claude-code";
+import type { ToolAdapter } from "@laup/core";
 import { cursorAdapter } from "@laup/cursor";
 import { describe, expect, it } from "vitest";
-import { SyncEngine } from "../index.js";
+import type { PropagationRecord } from "../index.js";
+import { SyncEngine, Watcher } from "../index.js";
 
 const ADAPTERS = [claudeCodeAdapter, cursorAdapter, aiderAdapter];
 
@@ -169,5 +171,177 @@ describe("SyncEngine", () => {
 
       expect(results[0]?.paths).toContain(join(dir, "CLAUDE.md"));
     });
+  });
+});
+
+describe("Watcher", () => {
+  it("creates a Watcher instance", () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const engine = new SyncEngine(ADAPTERS);
+    const watcher = new Watcher(engine, { source, tools: ["claude-code"], debounceMs: 10 });
+    expect(watcher).toBeInstanceOf(Watcher);
+  });
+
+  it("start() and stop() do not throw", () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const engine = new SyncEngine(ADAPTERS);
+    const watcher = new Watcher(engine, { source, tools: [], debounceMs: 10 });
+    expect(() => {
+      watcher.start();
+      watcher.stop();
+    }).not.toThrow();
+  });
+
+  it("start() is idempotent — calling twice does not throw", () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const engine = new SyncEngine(ADAPTERS);
+    const watcher = new Watcher(engine, { source, tools: [], debounceMs: 10 });
+    expect(() => {
+      watcher.start();
+      watcher.start();
+      watcher.stop();
+    }).not.toThrow();
+  });
+
+  it("emits 'propagated' with success=true on triggerSync()", async () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const engine = new SyncEngine(ADAPTERS);
+    const watcher = new Watcher(engine, { source, tools: ["claude-code"], debounceMs: 10 });
+
+    const record = await new Promise<PropagationRecord>((resolve, reject) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+        reject(new Error("Timeout waiting for 'propagated' event"));
+      }, 2000);
+      watcher.once("propagated", (r: unknown) => {
+        clearTimeout(timer);
+        resolve(r as PropagationRecord);
+      });
+      watcher.triggerSync();
+    });
+
+    watcher.stop();
+    expect(record.success).toBe(true);
+    expect(record.attempt).toBe(1);
+    expect(record.results).toHaveLength(1);
+    expect(record.results[0]?.success).toBe(true);
+  });
+
+  it("propagation record includes measurable latencyMs and startedAt", async () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const engine = new SyncEngine(ADAPTERS);
+    const watcher = new Watcher(engine, { source, tools: ["claude-code"], debounceMs: 10 });
+
+    const before = Date.now();
+    const record = await new Promise<PropagationRecord>((resolve, reject) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(
+        () => reject(new Error("Timeout")),
+        2000,
+      );
+      watcher.once("propagated", (r: unknown) => {
+        clearTimeout(timer);
+        resolve(r as PropagationRecord);
+      });
+      watcher.triggerSync();
+    });
+
+    watcher.stop();
+    expect(record.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(record.startedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("retries on adapter failure and emits 'error' after exhausting retries", async () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const failingAdapter: ToolAdapter = {
+      toolId: "fail-tool",
+      displayName: "Fail",
+      render(_doc) {
+        throw new Error("simulated render failure");
+      },
+      write(_rendered, _targetDir) {
+        return [];
+      },
+    };
+    const engine = new SyncEngine([failingAdapter]);
+    const watcher = new Watcher(engine, {
+      source,
+      tools: ["fail-tool"],
+      debounceMs: 10,
+      maxRetries: 2,
+      retryBaseMs: 5,
+    });
+
+    const records: PropagationRecord[] = [];
+    const err = await new Promise<Error>((resolve, reject) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(
+        () => reject(new Error("Timeout waiting for 'error' event")),
+        2000,
+      );
+      watcher.on("propagated", (r: unknown) => {
+        records.push(r as PropagationRecord);
+      });
+      watcher.once("error", (e: unknown) => {
+        clearTimeout(timer);
+        resolve(e as Error);
+      });
+      watcher.triggerSync();
+    });
+
+    watcher.stop();
+
+    // maxRetries=2 → initial attempt + 2 retries = 3 total propagated events
+    expect(records).toHaveLength(3);
+    expect(records.every((r) => !r.success)).toBe(true);
+    expect(records[0]?.attempt).toBe(1);
+    expect(records[1]?.attempt).toBe(2);
+    expect(records[2]?.attempt).toBe(3);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("propagation record error field is set when adapter fails", async () => {
+    const dir = makeTempDir();
+    const source = writeTempSource(dir, VALID_CANONICAL);
+    const failingAdapter: ToolAdapter = {
+      toolId: "fail-tool2",
+      displayName: "Fail2",
+      render(_doc) {
+        throw new Error("render error msg");
+      },
+      write(_rendered, _targetDir) {
+        return [];
+      },
+    };
+    const engine = new SyncEngine([failingAdapter]);
+    const watcher = new Watcher(engine, {
+      source,
+      tools: ["fail-tool2"],
+      debounceMs: 10,
+      maxRetries: 0,
+      retryBaseMs: 5,
+    });
+    watcher.on("error", () => {
+      // Suppress unhandled error event — maxRetries=0 emits error immediately
+    });
+
+    const record = await new Promise<PropagationRecord>((resolve, reject) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(
+        () => reject(new Error("Timeout")),
+        2000,
+      );
+      watcher.once("propagated", (r: unknown) => {
+        clearTimeout(timer);
+        resolve(r as PropagationRecord);
+      });
+      watcher.triggerSync();
+    });
+
+    watcher.stop();
+    expect(record.success).toBe(false);
+    expect(record.error).toBeDefined();
   });
 });

--- a/packages/config-hub/src/index.ts
+++ b/packages/config-hub/src/index.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
+import { type FSWatcher, readFileSync, watch } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { ToolAdapter, ValidationResult } from "@laup/core";
 import { parseCanonical, validateCanonical } from "@laup/core";
@@ -21,6 +22,37 @@ export interface SyncOptions {
   outputDir?: string;
   /** When true, skip writing files and return what would be written. */
   dryRun?: boolean;
+}
+
+export interface WatchOptions {
+  /** Absolute or relative path to the canonical instruction file to watch. */
+  source: string;
+  /** Tool IDs to sync on change. Pass empty array to sync all registered adapters. */
+  tools: string[];
+  /** Target directory for output files. Defaults to the source file's directory. */
+  outputDir?: string;
+  /** Maximum number of retry attempts after an initial failure. Default: 3. */
+  maxRetries?: number;
+  /** Base delay in milliseconds for exponential-backoff retries. Default: 1000. */
+  retryBaseMs?: number;
+  /** Debounce window in milliseconds to coalesce rapid file-change events. Default: 50. */
+  debounceMs?: number;
+}
+
+/** Emitted by Watcher after each propagation attempt (success or failure). */
+export interface PropagationRecord {
+  /** Wall-clock timestamp when this propagation attempt started (ms since epoch). */
+  startedAt: number;
+  /** Total latency of this propagation attempt in milliseconds. */
+  latencyMs: number;
+  /** 1-indexed attempt number (1 = initial, 2+ = retries). */
+  attempt: number;
+  /** True if all adapters propagated successfully on this attempt. */
+  success: boolean;
+  /** Per-adapter sync results. Empty array when engine.sync() threw before any adapter ran. */
+  results: SyncResult[];
+  /** Error message when success is false. */
+  error?: string;
 }
 
 export class SyncEngine {
@@ -74,5 +106,144 @@ export class SyncEngine {
     }
 
     return results;
+  }
+}
+
+/**
+ * Watches a canonical instruction file for changes and propagates updates to
+ * all registered tool adapters. Emits 'propagated' on each sync attempt and
+ * 'error' after exhausting all retry attempts.
+ *
+ * Satisfies CONF-003: detection + propagation completes well within the 30-second
+ * SLO (file-change events fire in < 100 ms; sync is synchronous); failures are
+ * retried with exponential backoff; latency is observable via the 'propagated' event.
+ */
+export class Watcher extends EventEmitter {
+  private readonly engine: SyncEngine;
+  private readonly source: string;
+  private readonly tools: string[];
+  private readonly outputDir: string;
+  private readonly maxRetries: number;
+  private readonly retryBaseMs: number;
+  private readonly debounceMs: number;
+  private fsWatcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(engine: SyncEngine, options: WatchOptions) {
+    super();
+    this.engine = engine;
+    this.source = resolve(options.source);
+    this.tools = options.tools;
+    this.outputDir = options.outputDir ?? dirname(resolve(options.source));
+    this.maxRetries = options.maxRetries ?? 3;
+    this.retryBaseMs = options.retryBaseMs ?? 1000;
+    this.debounceMs = options.debounceMs ?? 50;
+  }
+
+  /** Start watching the source file. Idempotent — calling twice has no effect. */
+  start(): void {
+    if (this.fsWatcher !== null) return;
+    this.fsWatcher = watch(this.source, () => {
+      this.handleChange();
+    });
+  }
+
+  /** Stop watching and cancel any pending debounce or retry timers. */
+  stop(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+    if (this.fsWatcher !== null) {
+      this.fsWatcher.close();
+      this.fsWatcher = null;
+    }
+  }
+
+  /**
+   * Programmatically trigger a debounced sync. Equivalent to a file-change event.
+   * Useful for manual sync requests from the CLI and for testing.
+   */
+  triggerSync(): void {
+    this.handleChange();
+  }
+
+  private handleChange(): void {
+    if (this.debounceTimer !== null) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      void this.propagate(1, this.tools);
+    }, this.debounceMs);
+  }
+
+  private async propagate(attempt: number, toolIds: string[]): Promise<void> {
+    const startedAt = Date.now();
+    let results: SyncResult[] = [];
+
+    try {
+      results = this.engine.sync({
+        source: this.source,
+        tools: toolIds,
+        outputDir: this.outputDir,
+      });
+    } catch (err) {
+      const latencyMs = Date.now() - startedAt;
+      const error = err instanceof Error ? err.message : String(err);
+      const record: PropagationRecord = {
+        startedAt,
+        latencyMs,
+        attempt,
+        success: false,
+        results: [],
+        error,
+      };
+      this.emit("propagated", record);
+      this.scheduleRetry(attempt, toolIds, err);
+      return;
+    }
+
+    const latencyMs = Date.now() - startedAt;
+    const failed = results.filter((r) => !r.success);
+
+    if (failed.length === 0) {
+      const record: PropagationRecord = { startedAt, latencyMs, attempt, success: true, results };
+      this.emit("propagated", record);
+    } else {
+      const error = `${failed.length} adapter(s) failed to propagate`;
+      const record: PropagationRecord = {
+        startedAt,
+        latencyMs,
+        attempt,
+        success: false,
+        results,
+        error,
+      };
+      this.emit("propagated", record);
+      const failedToolIds = failed.map((r) => r.tool);
+      this.scheduleRetry(attempt, failedToolIds, new Error(error));
+    }
+  }
+
+  /**
+   * Schedule the next retry attempt with exponential backoff.
+   * If attempt > maxRetries, emit 'error' instead of retrying.
+   */
+  private scheduleRetry(attempt: number, toolIds: string[], err: unknown): void {
+    if (attempt > this.maxRetries) {
+      this.emit("error", err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+    const delay = this.retryBaseMs * 2 ** (attempt - 1);
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.propagate(attempt + 1, toolIds);
+    }, delay);
   }
 }


### PR DESCRIPTION
Add Watcher class to config-hub that:
- Watches a canonical instruction file via fs.watch() (start/stop lifecycle)
- Exposes triggerSync() for programmatic/manual sync triggering
- Debounces rapid file-change events (configurable, default 50 ms)
- Calls SyncEngine.sync() and emits 'propagated' (PropagationRecord) on each attempt, providing startedAt, latencyMs, attempt, success, results
- Retries failed adapter propagations with exponential backoff (configurable maxRetries/retryBaseMs, default 3 retries / 1 s base)
- Emits 'error' after exhausting all retry attempts

Satisfies CONF-003 acceptance criteria:
- Watcher detects canonical document changes (fs.watch integration)
- Propagation completes well within the 30-second p95 SLO (sync is synchronous; detection latency < 100 ms on macOS/Linux)
- Failures are retried with exponential backoff
- Latency is observable via the PropagationRecord emitted on each attempt