### PR TITLE
feat(core): implement hierarchical instruction inheritance — CONF-005

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -6,7 +6,7 @@ import { aiderAdapter } from "@laup/aider";
 import { claudeCodeAdapter } from "@laup/claude-code";
 import type { SyncResult } from "@laup/config-hub";
 import { SyncEngine } from "@laup/config-hub";
-import { loadScopes, validateCanonical } from "@laup/core";
+import { loadHierarchy, loadScopes, validateCanonical } from "@laup/core";
 import { cursorAdapter } from "@laup/cursor";
 
 const ALL_ADAPTERS = [claudeCodeAdapter, cursorAdapter, aiderAdapter];
@@ -19,6 +19,8 @@ const { values: flags, positionals } = parseArgs({
     "output-dir": { type: "string", short: "o" },
     "dry-run": { type: "boolean", default: false },
     "merge-scopes": { type: "boolean", short: "m", default: false },
+    inherit: { type: "boolean", short: "i", default: false },
+    "stop-at": { type: "string" },
     team: { type: "string" },
     "org-path": { type: "string" },
     "teams-dir": { type: "string" },
@@ -41,6 +43,8 @@ Options for sync:
   --tools, -t        Comma-separated tool IDs (default: all registered adapters)
   --output-dir, -o   Target directory for output files (default: source file directory)
   --dry-run          Preview without writing any files
+  --inherit, -i      Load and merge parent directory instruction files (CONF-005)
+  --stop-at          Stop hierarchy traversal at this directory
   --merge-scopes, -m Merge org/team/project configs before syncing (CONF-004)
   --team             Team name for scope merging (overrides metadata.team)
   --org-path         Path to org config (default: ~/.config/laup/org.md)
@@ -87,6 +91,8 @@ if (command === "sync") {
   const outputDir = flags["output-dir"];
   const dryRun = flags["dry-run"] ?? false;
   const mergeScopes = flags["merge-scopes"] ?? false;
+  const inherit = flags.inherit ?? false;
+  const stopAt = flags["stop-at"];
   const team = flags.team;
   const orgPath = flags["org-path"];
   const teamsDir = flags["teams-dir"];
@@ -95,7 +101,26 @@ if (command === "sync") {
 
   let results: SyncResult[];
   try {
-    if (mergeScopes) {
+    if (inherit) {
+      // Load hierarchical instructions from parent directories (CONF-005)
+      const loadResult = loadHierarchy(resolve(source), {
+        stopAt,
+      });
+
+      // Log which files were loaded
+      const paths = loadResult.documents.map((d) => d.path);
+      console.log(`Loading hierarchy: ${paths.length} file(s)`);
+      for (const p of paths) {
+        console.log(`  ← ${p}`);
+      }
+
+      results = engine.syncDocument({
+        document: loadResult.merged,
+        tools: toolIds,
+        outputDir: outputDir ? resolve(outputDir) : dirname(resolve(source)),
+        dryRun,
+      });
+    } else if (mergeScopes) {
       // Load and merge documents from all scopes
       const loadResult = loadScopes(resolve(source), {
         team,

--- a/packages/core/src/__tests__/hierarchy.test.ts
+++ b/packages/core/src/__tests__/hierarchy.test.ts
@@ -1,0 +1,216 @@
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findRootInstruction, loadHierarchy } from "../hierarchy.js";
+
+describe("hierarchy", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `laup-hierarchy-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const writeDoc = (path: string, body: string, extra = "") => {
+    const content = `---
+version: "1.0"
+scope: project
+${extra}
+---
+
+${body}`;
+    writeFileSync(path, content);
+  };
+
+  const createDir = (...parts: string[]) => {
+    const dir = join(testDir, ...parts);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  };
+
+  describe("loadHierarchy", () => {
+    it("loads single file when no parents exist", () => {
+      const dir = createDir("project");
+      const filePath = join(dir, "laup.md");
+      writeDoc(filePath, "# Project");
+
+      const result = loadHierarchy(filePath);
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.merged.body).toBe("# Project");
+    });
+
+    it("loads and merges parent + child", () => {
+      const rootDir = createDir("project");
+      const childDir = createDir("project", "src");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+      writeDoc(join(childDir, "laup.md"), "# Child");
+
+      const result = loadHierarchy(join(childDir, "laup.md"));
+
+      expect(result.documents).toHaveLength(2);
+      expect(result.merged.body).toBe("# Root\n\n# Child");
+    });
+
+    it("loads deep hierarchy in correct order", () => {
+      const rootDir = createDir("project");
+      const srcDir = createDir("project", "src");
+      const apiDir = createDir("project", "src", "api");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+      writeDoc(join(srcDir, "laup.md"), "# Src");
+      writeDoc(join(apiDir, "laup.md"), "# API");
+
+      const result = loadHierarchy(join(apiDir, "laup.md"));
+
+      expect(result.documents).toHaveLength(3);
+      expect(result.documents[0]?.document.body).toContain("# Root");
+      expect(result.documents[1]?.document.body).toContain("# Src");
+      expect(result.documents[2]?.document.body).toContain("# API");
+      expect(result.merged.body).toBe("# Root\n\n# Src\n\n# API");
+    });
+
+    it("skips directories without instruction files", () => {
+      const rootDir = createDir("project");
+      const srcDir = createDir("project", "src"); // no laup.md here
+      const apiDir = createDir("project", "src", "api");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+      writeDoc(join(apiDir, "laup.md"), "# API");
+
+      const result = loadHierarchy(join(apiDir, "laup.md"));
+
+      expect(result.documents).toHaveLength(2);
+      expect(result.searched).toContain(srcDir);
+      expect(result.merged.body).toBe("# Root\n\n# API");
+    });
+
+    it("respects stopAt option", () => {
+      const rootDir = createDir("project");
+      const srcDir = createDir("project", "src");
+      const apiDir = createDir("project", "src", "api");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+      writeDoc(join(srcDir, "laup.md"), "# Src");
+      writeDoc(join(apiDir, "laup.md"), "# API");
+
+      const result = loadHierarchy(join(apiDir, "laup.md"), { stopAt: srcDir });
+
+      expect(result.documents).toHaveLength(2);
+      expect(result.merged.body).toBe("# Src\n\n# API");
+    });
+
+    it("respects maxDepth option", () => {
+      const d1 = createDir("d1");
+      const d2 = createDir("d1", "d2");
+      const d3 = createDir("d1", "d2", "d3");
+      const d4 = createDir("d1", "d2", "d3", "d4");
+
+      writeDoc(join(d1, "laup.md"), "# D1");
+      writeDoc(join(d2, "laup.md"), "# D2");
+      writeDoc(join(d3, "laup.md"), "# D3");
+      writeDoc(join(d4, "laup.md"), "# D4");
+
+      const result = loadHierarchy(join(d4, "laup.md"), { maxDepth: 2 });
+
+      // Should only load d3 and d4 (2 levels up from d4)
+      expect(result.documents).toHaveLength(2);
+    });
+
+    it("uses custom filename", () => {
+      const rootDir = createDir("project");
+      const childDir = createDir("project", "src");
+
+      writeDoc(join(rootDir, "INSTRUCTIONS.md"), "# Root");
+      writeDoc(join(childDir, "INSTRUCTIONS.md"), "# Child");
+
+      const result = loadHierarchy(join(childDir, "INSTRUCTIONS.md"), {
+        filename: "INSTRUCTIONS.md",
+      });
+
+      expect(result.documents).toHaveLength(2);
+    });
+
+    it("throws when target file not found", () => {
+      expect(() => loadHierarchy(join(testDir, "nonexistent.md"))).toThrow("Target file not found");
+    });
+
+    it("child overrides parent values", () => {
+      const rootDir = createDir("project");
+      const childDir = createDir("project", "src");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root", "metadata:\n  name: root-project");
+      writeDoc(join(childDir, "laup.md"), "# Child", "metadata:\n  name: child-project");
+
+      const result = loadHierarchy(join(childDir, "laup.md"));
+
+      expect(result.merged.frontmatter.metadata?.name).toBe("child-project");
+    });
+
+    it("detects circular reference via symlink", () => {
+      const rootDir = createDir("project");
+      const childDir = createDir("project", "child");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+
+      // Create a symlink that creates a cycle: project/child/loop -> project
+      try {
+        symlinkSync(rootDir, join(childDir, "loop"));
+
+        // This should detect the cycle when we try to load from the symlinked path
+        expect(() => loadHierarchy(join(childDir, "loop", "child", "loop", "laup.md"))).toThrow();
+      } catch {
+        // Symlink creation might fail on some systems/permissions - skip test
+      }
+    });
+  });
+
+  describe("findRootInstruction", () => {
+    it("finds root instruction walking up from child", () => {
+      const rootDir = createDir("project");
+      const childDir = createDir("project", "src", "api");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+
+      const root = findRootInstruction(childDir);
+
+      expect(root).toBe(join(rootDir, "laup.md"));
+    });
+
+    it("returns topmost instruction file", () => {
+      const rootDir = createDir("project");
+      const srcDir = createDir("project", "src");
+
+      writeDoc(join(rootDir, "laup.md"), "# Root");
+      writeDoc(join(srcDir, "laup.md"), "# Src");
+
+      const root = findRootInstruction(srcDir);
+
+      expect(root).toBe(join(rootDir, "laup.md"));
+    });
+
+    it("returns undefined when no instruction file found", () => {
+      const emptyDir = createDir("empty");
+
+      const root = findRootInstruction(emptyDir);
+
+      expect(root).toBeUndefined();
+    });
+
+    it("uses custom filename", () => {
+      const rootDir = createDir("project");
+
+      writeDoc(join(rootDir, "CUSTOM.md"), "# Custom");
+
+      const root = findRootInstruction(rootDir, "CUSTOM.md");
+
+      expect(root).toBe(join(rootDir, "CUSTOM.md"));
+    });
+  });
+});

--- a/packages/core/src/hierarchy.ts
+++ b/packages/core/src/hierarchy.ts
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { parseCanonicalString } from "./parse.js";
+import type { CanonicalInstruction } from "./schema.js";
+import type { ScopedDocument } from "./scope.js";
+import { mergeScopes } from "./scope.js";
+
+/**
+ * Options for loading hierarchical instructions.
+ */
+export interface HierarchyOptions {
+  /** Filename to search for in parent directories. Default: "laup.md" */
+  filename?: string | undefined;
+  /** Stop searching at this directory (exclusive). Default: filesystem root */
+  stopAt?: string | undefined;
+  /** Maximum depth to traverse. Default: 10 */
+  maxDepth?: number | undefined;
+}
+
+/**
+ * Result of loading hierarchical instructions.
+ */
+export interface HierarchyLoadResult {
+  /** Documents found, ordered from root (lowest precedence) to target (highest). */
+  documents: ScopedDocument[];
+  /** The merged result of all documents. */
+  merged: CanonicalInstruction;
+  /** Directories searched that didn't contain the instruction file. */
+  searched: string[];
+}
+
+/**
+ * Load instructions from a file and all parent directories containing the same filename.
+ *
+ * Traverses from the target file's directory up to the filesystem root (or stopAt),
+ * collecting all instruction files found. Merges them with parent directories
+ * having lower precedence than child directories.
+ *
+ * This implements Claude Code's parent-directory loading behavior (CONF-005).
+ *
+ * @param targetPath - Path to the target instruction file.
+ * @param options - Configuration options.
+ * @returns Load result with all documents and merged result.
+ * @throws Error if target file doesn't exist or circular reference detected.
+ */
+export function loadHierarchy(
+  targetPath: string,
+  options: HierarchyOptions = {},
+): HierarchyLoadResult {
+  const filename = options.filename ?? "laup.md";
+  const maxDepth = options.maxDepth ?? 10;
+  const resolvedTarget = resolve(targetPath);
+  const stopAt = options.stopAt ? resolve(options.stopAt) : undefined;
+
+  if (!existsSync(resolvedTarget)) {
+    throw new Error(`Target file not found: ${resolvedTarget}`);
+  }
+
+  // Get real path to detect symlink cycles
+  const realTarget = realpathSync(resolvedTarget);
+  const targetDir = dirname(realTarget);
+
+  // Collect all directories from target up to root/stopAt
+  const directories: string[] = [];
+  const seen = new Set<string>();
+  let current = targetDir;
+  let depth = 0;
+
+  while (depth < maxDepth) {
+    // Get real path to detect symlink cycles
+    let realCurrent: string;
+    try {
+      realCurrent = realpathSync(current);
+    } catch {
+      // Directory doesn't exist or can't be resolved
+      break;
+    }
+
+    // Check for circular reference (symlink cycle)
+    if (seen.has(realCurrent)) {
+      throw new Error(`Circular reference detected at: ${current}`);
+    }
+    seen.add(realCurrent);
+
+    directories.push(realCurrent);
+
+    // Check if we've reached the stop point
+    if (stopAt && (realCurrent === stopAt || realCurrent.startsWith(`${stopAt}/`))) {
+      // Include stopAt directory but don't go above it
+      if (realCurrent !== stopAt) {
+        const parent = dirname(realCurrent);
+        if (parent === stopAt) {
+          directories.push(parent);
+        }
+      }
+      break;
+    }
+
+    // Check if we've reached the filesystem root
+    const parent = dirname(realCurrent);
+    if (parent === realCurrent) {
+      break;
+    }
+
+    current = parent;
+    depth++;
+  }
+
+  // Reverse so root is first (lowest precedence)
+  directories.reverse();
+
+  // Load documents from each directory that has the file
+  const documents: ScopedDocument[] = [];
+  const searched: string[] = [];
+
+  for (const dir of directories) {
+    const filePath = join(dir, filename);
+
+    if (existsSync(filePath)) {
+      // Special case: target file - use the original path
+      const isTarget = realpathSync(filePath) === realTarget;
+      const actualPath = isTarget ? resolvedTarget : filePath;
+
+      const content = readFileSync(actualPath, "utf-8");
+      const document = parseCanonicalString(content);
+
+      documents.push({
+        scope: "project", // All hierarchy docs are project scope
+        path: actualPath,
+        document,
+      });
+    } else {
+      searched.push(dir);
+    }
+  }
+
+  if (documents.length === 0) {
+    throw new Error(`No instruction files found in hierarchy for: ${resolvedTarget}`);
+  }
+
+  // Merge all documents (first = lowest precedence, last = highest)
+  const merged = mergeScopes(documents);
+
+  return { documents, merged, searched };
+}
+
+/**
+ * Find the root instruction file by walking up from a starting directory.
+ *
+ * @param startDir - Directory to start searching from.
+ * @param filename - Filename to search for. Default: "laup.md"
+ * @returns Path to the root instruction file, or undefined if not found.
+ */
+export function findRootInstruction(startDir: string, filename = "laup.md"): string | undefined {
+  let current = resolve(startDir);
+  let rootPath: string | undefined;
+
+  const seen = new Set<string>();
+
+  while (true) {
+    const realCurrent = realpathSync(current);
+    if (seen.has(realCurrent)) break;
+    seen.add(realCurrent);
+
+    const filePath = join(realCurrent, filename);
+    if (existsSync(filePath)) {
+      rootPath = filePath;
+    }
+
+    const parent = dirname(realCurrent);
+    if (parent === realCurrent) break;
+    current = parent;
+  }
+
+  return rootPath;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export type { ToolAdapter } from "./adapter.js";
+export type { HierarchyLoadResult, HierarchyOptions } from "./hierarchy.js";
+export { findRootInstruction, loadHierarchy } from "./hierarchy.js";
 export type { FieldIssue } from "./parse.js";
 export { ParseError, parseCanonical, parseCanonicalString } from "./parse.js";
 export type { CanonicalInstruction, Frontmatter, ToolOverrides } from "./schema.js";


### PR DESCRIPTION
## Summary
Implements CONF-005: hierarchical instruction inheritance from parent directories.

## Changes
- Add `loadHierarchy()` to walk up directory tree and load parent `laup.md` files
- Add `findRootInstruction()` helper for locating instruction files
- Parent directories have lower precedence than child (child wins on conflict)
- Add CLI flags: `--inherit`, `--stop-at`
- Detect circular references via symlinks

## Testing
- 14 new tests for hierarchy loading
- All 116+ tests passing

Closes #8