### PR TITLE
feat(core): implement @include directive for modular composition — CONF-006

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -6,7 +6,13 @@ import { aiderAdapter } from "@laup/aider";
 import { claudeCodeAdapter } from "@laup/claude-code";
 import type { SyncResult } from "@laup/config-hub";
 import { SyncEngine } from "@laup/config-hub";
-import { loadHierarchy, loadScopes, validateCanonical } from "@laup/core";
+import {
+  loadHierarchy,
+  loadScopes,
+  parseCanonical,
+  processIncludes,
+  validateCanonical,
+} from "@laup/core";
 import { cursorAdapter } from "@laup/cursor";
 
 const ALL_ADAPTERS = [claudeCodeAdapter, cursorAdapter, aiderAdapter];
@@ -21,6 +27,7 @@ const { values: flags, positionals } = parseArgs({
     "merge-scopes": { type: "boolean", short: "m", default: false },
     inherit: { type: "boolean", short: "i", default: false },
     "stop-at": { type: "string" },
+    "expand-includes": { type: "boolean", short: "e", default: false },
     team: { type: "string" },
     "org-path": { type: "string" },
     "teams-dir": { type: "string" },
@@ -45,6 +52,7 @@ Options for sync:
   --dry-run          Preview without writing any files
   --inherit, -i      Load and merge parent directory instruction files (CONF-005)
   --stop-at          Stop hierarchy traversal at this directory
+  --expand-includes, -e  Expand @include directives before syncing (CONF-006)
   --merge-scopes, -m Merge org/team/project configs before syncing (CONF-004)
   --team             Team name for scope merging (overrides metadata.team)
   --org-path         Path to org config (default: ~/.config/laup/org.md)
@@ -92,6 +100,7 @@ if (command === "sync") {
   const dryRun = flags["dry-run"] ?? false;
   const mergeScopes = flags["merge-scopes"] ?? false;
   const inherit = flags.inherit ?? false;
+  const expandIncludes = flags["expand-includes"] ?? false;
   const stopAt = flags["stop-at"];
   const team = flags.team;
   const orgPath = flags["org-path"];
@@ -101,51 +110,48 @@ if (command === "sync") {
 
   let results: SyncResult[];
   try {
+    // Load document based on mode
+    let doc = parseCanonical(resolve(source));
+
     if (inherit) {
       // Load hierarchical instructions from parent directories (CONF-005)
-      const loadResult = loadHierarchy(resolve(source), {
-        stopAt,
-      });
-
-      // Log which files were loaded
+      const loadResult = loadHierarchy(resolve(source), { stopAt });
       const paths = loadResult.documents.map((d) => d.path);
       console.log(`Loading hierarchy: ${paths.length} file(s)`);
       for (const p of paths) {
         console.log(`  ← ${p}`);
       }
-
-      results = engine.syncDocument({
-        document: loadResult.merged,
-        tools: toolIds,
-        outputDir: outputDir ? resolve(outputDir) : dirname(resolve(source)),
-        dryRun,
-      });
+      doc = loadResult.merged;
     } else if (mergeScopes) {
-      // Load and merge documents from all scopes
-      const loadResult = loadScopes(resolve(source), {
-        team,
-        orgPath,
-        teamsDir,
-      });
-
-      // Log which scopes were loaded
+      // Load and merge documents from all scopes (CONF-004)
+      const loadResult = loadScopes(resolve(source), { team, orgPath, teamsDir });
       const scopeList = loadResult.documents.map((d) => d.scope).join(" → ");
       console.log(`Merging scopes: ${scopeList}`);
-
-      results = engine.syncDocument({
-        document: loadResult.merged,
-        tools: toolIds,
-        outputDir: outputDir ? resolve(outputDir) : dirname(resolve(source)),
-        dryRun,
-      });
-    } else {
-      results = engine.sync({
-        source: resolve(source),
-        tools: toolIds,
-        ...(outputDir ? { outputDir: resolve(outputDir) } : {}),
-        dryRun,
-      });
+      doc = loadResult.merged;
     }
+
+    // Expand @include directives if requested (CONF-006)
+    if (expandIncludes) {
+      const includeResult = processIncludes(doc.body, resolve(source));
+      if (includeResult.includedFiles.length > 0) {
+        console.log(`Expanded includes: ${includeResult.includedFiles.length} file(s)`);
+        for (const f of includeResult.includedFiles) {
+          console.log(`  + ${f}`);
+        }
+      }
+      for (const w of includeResult.warnings) {
+        console.warn(`  ⚠ ${w}`);
+      }
+      doc = { ...doc, body: includeResult.content };
+    }
+
+    // Sync the processed document
+    results = engine.syncDocument({
+      document: doc,
+      tools: toolIds,
+      outputDir: outputDir ? resolve(outputDir) : dirname(resolve(source)),
+      dryRun,
+    });
   } catch (err) {
     console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);

--- a/packages/core/src/__tests__/include.test.ts
+++ b/packages/core/src/__tests__/include.test.ts
@@ -1,0 +1,201 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractIncludePaths, hasIncludes, processIncludes } from "../include.js";
+
+describe("include", () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `laup-include-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  const writeFile = (name: string, content: string) => {
+    const path = join(testDir, name);
+    mkdirSync(join(testDir, ...name.split("/").slice(0, -1)), { recursive: true });
+    writeFileSync(path, content);
+    return path;
+  };
+
+  describe("processIncludes", () => {
+    it("returns content unchanged when no includes present", () => {
+      const sourcePath = writeFile("main.md", "# Hello\n\nWorld");
+
+      const result = processIncludes("# Hello\n\nWorld", sourcePath);
+
+      expect(result.content).toBe("# Hello\n\nWorld");
+      expect(result.includedFiles).toHaveLength(0);
+    });
+
+    it("expands single @include directive", () => {
+      writeFile("shared/rules.md", "# Rules\n\n- Rule 1\n- Rule 2");
+      const sourcePath = writeFile("main.md", "# Main\n\n@include ./shared/rules.md\n\n# End");
+
+      const result = processIncludes("# Main\n\n@include ./shared/rules.md\n\n# End", sourcePath);
+
+      expect(result.content).toContain("# Main");
+      expect(result.content).toContain("# Rules");
+      expect(result.content).toContain("- Rule 1");
+      expect(result.content).toContain("# End");
+      expect(result.includedFiles).toHaveLength(1);
+    });
+
+    it("expands multiple @include directives", () => {
+      writeFile("a.md", "Content A");
+      writeFile("b.md", "Content B");
+      const sourcePath = writeFile("main.md", "@include ./a.md\n\n@include ./b.md");
+
+      const result = processIncludes("@include ./a.md\n\n@include ./b.md", sourcePath);
+
+      expect(result.content).toContain("Content A");
+      expect(result.content).toContain("Content B");
+      expect(result.includedFiles).toHaveLength(2);
+    });
+
+    it("supports quoted paths with spaces", () => {
+      writeFile("path with spaces/file.md", "Spaced content");
+      const sourcePath = writeFile("main.md", '@include "./path with spaces/file.md"');
+
+      const result = processIncludes('@include "./path with spaces/file.md"', sourcePath);
+
+      expect(result.content).toContain("Spaced content");
+    });
+
+    it("supports single-quoted paths", () => {
+      writeFile("shared.md", "Single quoted");
+      const sourcePath = writeFile("main.md", "@include './shared.md'");
+
+      const result = processIncludes("@include './shared.md'", sourcePath);
+
+      expect(result.content).toContain("Single quoted");
+    });
+
+    it("processes nested includes", () => {
+      writeFile("level2.md", "Level 2 content");
+      writeFile("level1.md", "Level 1\n\n@include ./level2.md");
+      const sourcePath = writeFile("main.md", "Main\n\n@include ./level1.md");
+
+      const result = processIncludes("Main\n\n@include ./level1.md", sourcePath);
+
+      expect(result.content).toContain("Main");
+      expect(result.content).toContain("Level 1");
+      expect(result.content).toContain("Level 2 content");
+      expect(result.includedFiles).toHaveLength(2);
+    });
+
+    it("throws on circular include", () => {
+      writeFile("b.md", "@include ./a.md");
+      writeFile("a.md", "@include ./b.md");
+      const sourcePath = writeFile("main.md", "@include ./a.md");
+
+      expect(() => processIncludes("@include ./a.md", sourcePath)).toThrow(
+        "Circular include detected",
+      );
+    });
+
+    it("throws on self-include", () => {
+      const sourcePath = writeFile("main.md", "@include ./main.md");
+
+      expect(() => processIncludes("@include ./main.md", sourcePath)).toThrow(
+        "Circular include detected",
+      );
+    });
+
+    it("throws when max depth exceeded", () => {
+      // Create a chain of 15 includes
+      for (let i = 14; i >= 1; i--) {
+        writeFile(`level${i}.md`, `@include ./level${i + 1}.md`);
+      }
+      writeFile("level15.md", "Bottom");
+      const sourcePath = writeFile("main.md", "@include ./level1.md");
+
+      expect(() => processIncludes("@include ./level1.md", sourcePath, { maxDepth: 10 })).toThrow(
+        "Maximum include depth",
+      );
+    });
+
+    it("handles missing include file gracefully with warning", () => {
+      const sourcePath = writeFile("main.md", "@include ./nonexistent.md");
+
+      const result = processIncludes("@include ./nonexistent.md", sourcePath);
+
+      expect(result.content).toContain("<!-- Include not found");
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain("not found");
+    });
+
+    it("resolves includes relative to including file, not source", () => {
+      writeFile("shared/deep/content.md", "Deep content");
+      writeFile("shared/include-deep.md", "@include ./deep/content.md");
+      const sourcePath = writeFile("main.md", "@include ./shared/include-deep.md");
+
+      const result = processIncludes("@include ./shared/include-deep.md", sourcePath);
+
+      expect(result.content).toContain("Deep content");
+    });
+
+    it("supports absolute paths", () => {
+      const absPath = writeFile("absolute.md", "Absolute content");
+      const sourcePath = writeFile("main.md", `@include ${absPath}`);
+
+      const result = processIncludes(`@include ${absPath}`, sourcePath);
+
+      expect(result.content).toContain("Absolute content");
+    });
+
+    it("preserves non-include content", () => {
+      writeFile("included.md", "INCLUDED\n");
+      const sourcePath = writeFile("main.md", "before\n\n@include ./included.md\nafter");
+
+      const result = processIncludes("before\n\n@include ./included.md\nafter", sourcePath);
+
+      expect(result.content).toBe("before\n\nINCLUDED\n\nafter");
+    });
+  });
+
+  describe("hasIncludes", () => {
+    it("returns true when @include is present", () => {
+      expect(hasIncludes("@include ./file.md")).toBe(true);
+    });
+
+    it("returns false when no @include is present", () => {
+      expect(hasIncludes("# Just markdown\n\nNo includes here")).toBe(false);
+    });
+
+    it("returns true for quoted includes", () => {
+      expect(hasIncludes('@include "file.md"')).toBe(true);
+    });
+  });
+
+  describe("extractIncludePaths", () => {
+    it("extracts single include path", () => {
+      const paths = extractIncludePaths("@include ./file.md");
+
+      expect(paths).toEqual(["./file.md"]);
+    });
+
+    it("extracts multiple include paths", () => {
+      const paths = extractIncludePaths("@include ./a.md\n\n@include ./b.md\n\n@include ./c.md");
+
+      expect(paths).toEqual(["./a.md", "./b.md", "./c.md"]);
+    });
+
+    it("extracts quoted paths correctly", () => {
+      const paths = extractIncludePaths('@include "./path with space.md"');
+
+      expect(paths).toEqual(["./path with space.md"]);
+    });
+
+    it("returns empty array when no includes", () => {
+      const paths = extractIncludePaths("# No includes");
+
+      expect(paths).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/include.ts
+++ b/packages/core/src/include.ts
@@ -1,0 +1,157 @@
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+
+/**
+ * Options for processing includes.
+ */
+export interface IncludeOptions {
+  /** Maximum include depth to prevent runaway recursion. Default: 10 */
+  maxDepth?: number | undefined;
+  /** Base directory for resolving relative paths. Default: source file's directory */
+  baseDir?: string | undefined;
+}
+
+/**
+ * Result of processing includes.
+ */
+export interface IncludeResult {
+  /** The expanded content with includes resolved. */
+  content: string;
+  /** All files that were included (for dependency tracking). */
+  includedFiles: string[];
+  /** Any warnings encountered during processing. */
+  warnings: string[];
+}
+
+/** Pattern to match @include directives. Supports @include path or @include "path" */
+const INCLUDE_PATTERN = /^@include\s+(?:"([^"]+)"|'([^']+)'|(\S+))\s*$/gm;
+
+/**
+ * Process @include directives in content, recursively expanding included files.
+ *
+ * Supports the following syntax:
+ * - `@include ./relative/path.md`
+ * - `@include /absolute/path.md`
+ * - `@include "path with spaces.md"`
+ * - `@include 'path with spaces.md'`
+ *
+ * Include directives must be on their own line. The entire line is replaced
+ * with the contents of the included file.
+ *
+ * @param content - The content to process.
+ * @param sourcePath - Path to the source file (for resolving relative includes).
+ * @param options - Processing options.
+ * @returns The expanded content with all includes resolved.
+ * @throws Error if circular include detected or max depth exceeded.
+ */
+export function processIncludes(
+  content: string,
+  sourcePath: string,
+  options: IncludeOptions = {},
+): IncludeResult {
+  const maxDepth = options.maxDepth ?? 10;
+  const baseDir = options.baseDir ?? dirname(resolve(sourcePath));
+
+  const includedFiles: string[] = [];
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+
+  // Add source file to seen set to detect circular includes
+  const realSourcePath = realpathSync(resolve(sourcePath));
+  seen.add(realSourcePath);
+
+  const expanded = expandIncludes(content, baseDir, {
+    maxDepth,
+    currentDepth: 0,
+    seen,
+    includedFiles,
+    warnings,
+  });
+
+  return { content: expanded, includedFiles, warnings };
+}
+
+interface ExpandContext {
+  maxDepth: number;
+  currentDepth: number;
+  seen: Set<string>;
+  includedFiles: string[];
+  warnings: string[];
+}
+
+function expandIncludes(content: string, baseDir: string, ctx: ExpandContext): string {
+  if (ctx.currentDepth >= ctx.maxDepth) {
+    throw new Error(`Maximum include depth (${ctx.maxDepth}) exceeded`);
+  }
+
+  // Process each @include directive
+  return content.replace(INCLUDE_PATTERN, (_match, quoted1, quoted2, unquoted) => {
+    const includePath = quoted1 ?? quoted2 ?? unquoted;
+
+    // Resolve the include path
+    const resolvedPath = isAbsolute(includePath)
+      ? resolve(includePath)
+      : resolve(baseDir, includePath);
+
+    // Check if file exists
+    if (!existsSync(resolvedPath)) {
+      ctx.warnings.push(`Include file not found: ${includePath} (resolved to ${resolvedPath})`);
+      return `<!-- Include not found: ${includePath} -->`;
+    }
+
+    // Get real path to detect circular includes via symlinks
+    let realPath: string;
+    try {
+      realPath = realpathSync(resolvedPath);
+    } catch {
+      ctx.warnings.push(`Cannot resolve include path: ${includePath}`);
+      return `<!-- Cannot resolve: ${includePath} -->`;
+    }
+
+    // Check for circular include
+    if (ctx.seen.has(realPath)) {
+      throw new Error(`Circular include detected: ${includePath} (${realPath})`);
+    }
+
+    // Mark as seen
+    ctx.seen.add(realPath);
+    ctx.includedFiles.push(realPath);
+
+    // Read and recursively process the included file
+    const includedContent = readFileSync(resolvedPath, "utf-8");
+    const includeDir = dirname(resolvedPath);
+
+    // Recursively expand includes in the included content
+    const expanded = expandIncludes(includedContent, includeDir, {
+      ...ctx,
+      currentDepth: ctx.currentDepth + 1,
+    });
+
+    return expanded;
+  });
+}
+
+/**
+ * Check if content contains any @include directives.
+ */
+export function hasIncludes(content: string): boolean {
+  INCLUDE_PATTERN.lastIndex = 0;
+  return INCLUDE_PATTERN.test(content);
+}
+
+/**
+ * Extract all include paths from content without resolving them.
+ */
+export function extractIncludePaths(content: string): string[] {
+  const paths: string[] = [];
+
+  INCLUDE_PATTERN.lastIndex = 0;
+  for (const match of content.matchAll(INCLUDE_PATTERN)) {
+    const path = match[1] ?? match[2] ?? match[3];
+    if (path) {
+      paths.push(path);
+    }
+  }
+
+  return paths;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 export type { ToolAdapter } from "./adapter.js";
 export type { HierarchyLoadResult, HierarchyOptions } from "./hierarchy.js";
 export { findRootInstruction, loadHierarchy } from "./hierarchy.js";
+export type { IncludeOptions, IncludeResult } from "./include.js";
+export { extractIncludePaths, hasIncludes, processIncludes } from "./include.js";
 export type { FieldIssue } from "./parse.js";
 export { ParseError, parseCanonical, parseCanonicalString } from "./parse.js";
 export type { CanonicalInstruction, Frontmatter, ToolOverrides } from "./schema.js";


### PR DESCRIPTION
## Summary
Implements CONF-006: modular instruction composition with @include mechanism.

## Changes
- Add `processIncludes()` to recursively expand @include directives
- Support `@include ./path.md`, `@include "path with spaces.md"`, `@include 'path'`
- Support absolute paths and paths relative to including file
- Detect circular includes and respect maxDepth
- Add `extractIncludePaths()` and `hasIncludes()` utility functions
- Add CLI flag: `--expand-includes`

## Testing
- 20 new tests for include processing
- All 136 tests passing

Closes #9