### PR TITLE
feat(cli): implement dry-run diff report — CONF-020

### DIFF
--- a/packages/adapters/aider/src/index.ts
+++ b/packages/adapters/aider/src/index.ts
@@ -80,6 +80,10 @@ export class AiderAdapter implements ToolAdapter {
 
     return [configPath, conventionsPath];
   }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, ".aider.conf.yml"), join(targetDir, CONVENTIONS_FILE)];
+  }
 }
 
 export const aiderAdapter = new AiderAdapter();

--- a/packages/adapters/claude-code/src/index.ts
+++ b/packages/adapters/claude-code/src/index.ts
@@ -26,6 +26,10 @@ export class ClaudeCodeAdapter implements ToolAdapter {
     writeFileSync(outPath, `${rendered}\n`, "utf-8");
     return [outPath];
   }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, "CLAUDE.md")];
+  }
 }
 
 export const claudeCodeAdapter = new ClaudeCodeAdapter();

--- a/packages/adapters/cursor/src/index.ts
+++ b/packages/adapters/cursor/src/index.ts
@@ -63,6 +63,10 @@ export class CursorAdapter implements ToolAdapter {
 
     return written;
   }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, ".cursorrules"), join(targetDir, ".cursor", "rules", "laup.mdc")];
+  }
 }
 
 export const cursorAdapter = new CursorAdapter();

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -5,7 +5,7 @@ import { parseArgs } from "node:util";
 import { aiderAdapter } from "@laup/aider";
 import { claudeCodeAdapter } from "@laup/claude-code";
 import type { SyncResult } from "@laup/config-hub";
-import { SyncEngine } from "@laup/config-hub";
+import { formatDiff, SyncEngine } from "@laup/config-hub";
 import {
   loadHierarchy,
   loadScopes,
@@ -24,6 +24,7 @@ const { values: flags, positionals } = parseArgs({
     tools: { type: "string", short: "t" },
     "output-dir": { type: "string", short: "o" },
     "dry-run": { type: "boolean", default: false },
+    diff: { type: "boolean", short: "d", default: false },
     "merge-scopes": { type: "boolean", short: "m", default: false },
     inherit: { type: "boolean", short: "i", default: false },
     "stop-at": { type: "string" },
@@ -52,6 +53,7 @@ Options for sync:
   --category, -c     Filter tools by category: ide, cli, agent, other (CONF-015)
   --output-dir, -o   Target directory for output files (default: source file directory)
   --dry-run          Preview rendered output without writing files (CONF-016)
+  --diff, -d         Show diff against existing files (with --dry-run) (CONF-020)
   --inherit, -i      Load and merge parent directory instruction files (CONF-005)
   --stop-at          Stop hierarchy traversal at this directory
   --expand-includes, -e  Expand @include directives before syncing (CONF-006)
@@ -100,6 +102,7 @@ if (command === "sync") {
   const categoryArg = flags.category;
   const outputDir = flags["output-dir"];
   const dryRun = flags["dry-run"] ?? false;
+  const showDiff = flags.diff ?? false;
   const mergeScopes = flags["merge-scopes"] ?? false;
   const inherit = flags.inherit ?? false;
   const expandIncludes = flags["expand-includes"] ?? false;
@@ -172,21 +175,56 @@ if (command === "sync") {
 
     // Preview mode: show rendered content without writing (CONF-016)
     if (dryRun) {
-      const previews = engine.preview(doc, toolIds);
+      const targetDir = outputDir ? resolve(outputDir) : dirname(resolve(source));
       let hasError = false;
 
-      console.log("\n=== PREVIEW (dry run — no files written) ===\n");
+      if (showDiff) {
+        // Diff mode: show what would change (CONF-020)
+        const diffs = engine.previewWithDiff(doc, targetDir, toolIds);
 
-      for (const preview of previews) {
-        if (preview.success) {
-          console.log(`── ${preview.tool} ──────────────────────────────────────`);
-          for (const content of preview.content) {
-            console.log(content);
-            console.log("");
+        console.log("\n=== DIFF PREVIEW (dry run — no files written) ===\n");
+
+        for (const result of diffs) {
+          if (result.success) {
+            for (const file of result.files) {
+              const status = file.exists
+                ? file.diff.hasChanges
+                  ? "MODIFIED"
+                  : "UNCHANGED"
+                : "NEW";
+              console.log(`── ${result.tool}: ${file.path} [${status}] ──`);
+
+              if (!file.exists) {
+                console.log("(new file will be created)");
+              } else if (file.diff.hasChanges) {
+                console.log(formatDiff(file.diff));
+              } else {
+                console.log("(no changes)");
+              }
+              console.log("");
+            }
+          } else {
+            console.error(`✗ ${result.tool}: ${result.error}`);
+            hasError = true;
           }
-        } else {
-          console.error(`✗ ${preview.tool}: ${preview.error}`);
-          hasError = true;
+        }
+      } else {
+        // Standard preview: show full rendered content
+        const previews = engine.preview(doc, toolIds);
+
+        console.log("\n=== PREVIEW (dry run — no files written) ===\n");
+
+        for (const preview of previews) {
+          if (preview.success) {
+            console.log(`── ${preview.tool} ──────────────────────────────────────`);
+            for (const content of preview.content) {
+              console.log(content);
+              console.log("");
+            }
+          } else {
+            console.error(`✗ ${preview.tool}: ${preview.error}`);
+            hasError = true;
+          }
         }
       }
 

--- a/packages/config-hub/src/diff.ts
+++ b/packages/config-hub/src/diff.ts
@@ -1,0 +1,195 @@
+/**
+ * Simple line-based diff utility for comparing rendered outputs (CONF-020).
+ * Produces unified diff format for human readability.
+ */
+
+export interface DiffLine {
+  type: "context" | "add" | "remove";
+  content: string;
+  lineNumber?: number;
+}
+
+export interface DiffResult {
+  hasChanges: boolean;
+  lines: DiffLine[];
+  summary: {
+    added: number;
+    removed: number;
+    unchanged: number;
+  };
+}
+
+/**
+ * Compute a simple line-by-line diff between two strings.
+ * Uses a basic LCS-based approach for small files.
+ */
+export function computeDiff(oldContent: string, newContent: string): DiffResult {
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+
+  const lines: DiffLine[] = [];
+  let added = 0;
+  let removed = 0;
+  let unchanged = 0;
+
+  // Simple Myers-like diff using LCS
+  const lcs = longestCommonSubsequence(oldLines, newLines);
+  let oldIdx = 0;
+  let newIdx = 0;
+  let lcsIdx = 0;
+
+  while (oldIdx < oldLines.length || newIdx < newLines.length) {
+    const oldLine = oldLines[oldIdx];
+    const newLine = newLines[newIdx];
+    const lcsLine = lcs[lcsIdx];
+
+    if (lcsIdx < lcs.length && oldIdx < oldLines.length && oldLine === lcsLine) {
+      // Match in old - check if it's also current in new
+      if (newIdx < newLines.length && newLine === lcsLine) {
+        lines.push({ type: "context", content: oldLine ?? "" });
+        unchanged++;
+        oldIdx++;
+        newIdx++;
+        lcsIdx++;
+      } else if (newIdx < newLines.length && newLine !== undefined) {
+        // New has something different before matching
+        lines.push({ type: "add", content: newLine, lineNumber: newIdx + 1 });
+        added++;
+        newIdx++;
+      } else if (oldLine !== undefined) {
+        // Old still has content
+        lines.push({ type: "remove", content: oldLine, lineNumber: oldIdx + 1 });
+        removed++;
+        oldIdx++;
+      }
+    } else if (oldIdx < oldLines.length && oldLine !== undefined) {
+      lines.push({ type: "remove", content: oldLine, lineNumber: oldIdx + 1 });
+      removed++;
+      oldIdx++;
+    } else if (newIdx < newLines.length && newLine !== undefined) {
+      lines.push({ type: "add", content: newLine, lineNumber: newIdx + 1 });
+      added++;
+      newIdx++;
+    } else {
+      // Safety valve to prevent infinite loop
+      oldIdx++;
+      newIdx++;
+    }
+  }
+
+  return {
+    hasChanges: added > 0 || removed > 0,
+    lines,
+    summary: { added, removed, unchanged },
+  };
+}
+
+/**
+ * Find longest common subsequence of two arrays (for diff computation).
+ */
+function longestCommonSubsequence(a: string[], b: string[]): string[] {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const row = dp[i];
+      const prevRow = dp[i - 1];
+      if (!row || !prevRow) continue;
+
+      if (a[i - 1] === b[j - 1]) {
+        row[j] = (prevRow[j - 1] ?? 0) + 1;
+      } else {
+        row[j] = Math.max(prevRow[j] ?? 0, row[j - 1] ?? 0);
+      }
+    }
+  }
+
+  // Backtrack to find the actual LCS
+  const lcs: string[] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    const aVal = a[i - 1];
+    const bVal = b[j - 1];
+    const dpUp = dp[i - 1]?.[j] ?? 0;
+    const dpLeft = dp[i]?.[j - 1] ?? 0;
+
+    if (aVal !== undefined && aVal === bVal) {
+      lcs.unshift(aVal);
+      i--;
+      j--;
+    } else if (dpUp > dpLeft) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  return lcs;
+}
+
+/**
+ * Format diff result as unified diff string.
+ */
+export function formatDiff(diff: DiffResult, contextLines = 3): string {
+  if (!diff.hasChanges) {
+    return "(no changes)";
+  }
+
+  const output: string[] = [];
+  const lines = diff.lines;
+
+  // Simple approach: output all lines with prefixes
+  for (const line of lines) {
+    switch (line.type) {
+      case "add":
+        output.push(`+${line.content}`);
+        break;
+      case "remove":
+        output.push(`-${line.content}`);
+        break;
+      case "context":
+        output.push(` ${line.content}`);
+        break;
+    }
+  }
+
+  // Trim excessive context (keep only contextLines around changes)
+  const result: string[] = [];
+  let lastChangeIdx = -contextLines - 1;
+
+  for (let i = 0; i < output.length; i++) {
+    const line = output[i];
+    if (!line) continue;
+    const isChange = line.startsWith("+") || line.startsWith("-");
+
+    if (isChange) {
+      // Include context lines before this change
+      const contextStart = Math.max(lastChangeIdx + contextLines + 1, i - contextLines);
+      if (contextStart > lastChangeIdx + contextLines + 1 && result.length > 0) {
+        result.push("...");
+      }
+      for (let j = contextStart; j < i; j++) {
+        const contextLine = output[j];
+        if (contextLine && !result.includes(contextLine)) {
+          result.push(contextLine);
+        }
+      }
+      result.push(line);
+      lastChangeIdx = i;
+    }
+  }
+
+  // Include trailing context
+  const trailingEnd = Math.min(output.length, lastChangeIdx + contextLines + 1);
+  for (let i = lastChangeIdx + 1; i < trailingEnd; i++) {
+    const line = output[i];
+    if (line) {
+      result.push(line);
+    }
+  }
+
+  return result.join("\n");
+}

--- a/packages/config-hub/src/index.ts
+++ b/packages/config-hub/src/index.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from "node:events";
-import { type FSWatcher, readFileSync, watch } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { existsSync, type FSWatcher, readFileSync, watch } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import type { CanonicalInstruction, ToolAdapter, ValidationResult } from "@laup/core";
 import { parseCanonical, validateCanonical } from "@laup/core";
+import { computeDiff, type DiffResult } from "./diff.js";
 
 export type { ValidationResult };
+export type { DiffLine, DiffResult } from "./diff.js";
+export { computeDiff, formatDiff } from "./diff.js";
 
 export interface SyncResult {
   tool: string;
@@ -18,6 +21,18 @@ export interface PreviewResult {
   success: boolean;
   /** Rendered content for each output file. Array for tools with multiple outputs. */
   content: string[];
+  error?: string;
+}
+
+export interface DiffPreviewResult {
+  tool: string;
+  success: boolean;
+  /** Per-file diff results with path and diff */
+  files: Array<{
+    path: string;
+    exists: boolean;
+    diff: DiffResult;
+  }>;
   error?: string;
 }
 
@@ -177,6 +192,83 @@ export class SyncEngine {
     }
 
     return results;
+  }
+
+  /**
+   * Preview with diff: compare rendered output against existing files (CONF-020).
+   * Returns per-file diff results showing what would change.
+   */
+  previewWithDiff(
+    document: CanonicalInstruction,
+    outputDir: string,
+    tools: string[] = [],
+  ): DiffPreviewResult[] {
+    const toolIds = tools.length > 0 ? tools : this.registeredTools;
+    const results: DiffPreviewResult[] = [];
+
+    for (const toolId of toolIds) {
+      const adapter = this.adapters.get(toolId);
+      if (!adapter) {
+        results.push({
+          tool: toolId,
+          success: false,
+          files: [],
+          error: `No adapter registered for tool: ${toolId}`,
+        });
+        continue;
+      }
+
+      try {
+        const rendered = adapter.render(document);
+        const contentArray = Array.isArray(rendered) ? rendered : [rendered];
+
+        // Get expected output paths
+        const paths = adapter.getOutputPaths
+          ? adapter.getOutputPaths(outputDir)
+          : this.inferPaths(toolId, outputDir, contentArray.length);
+
+        const files: DiffPreviewResult["files"] = [];
+
+        for (let i = 0; i < contentArray.length; i++) {
+          const filePath = paths[i] ?? join(outputDir, `${toolId}-output-${i}`);
+          const newContent = contentArray[i] ?? "";
+
+          const fileExists = existsSync(filePath);
+          const oldContent = fileExists ? readFileSync(filePath, "utf-8") : "";
+
+          const diff = computeDiff(oldContent, newContent);
+          files.push({ path: filePath, exists: fileExists, diff });
+        }
+
+        results.push({ tool: toolId, success: true, files });
+      } catch (err) {
+        results.push({
+          tool: toolId,
+          success: false,
+          files: [],
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  /** Fallback path inference for adapters without getOutputPaths */
+  private inferPaths(toolId: string, outputDir: string, count: number): string[] {
+    // Known conventions for common tools
+    const conventions: Record<string, string[]> = {
+      cursor: [join(outputDir, ".cursorrules"), join(outputDir, ".cursor", "rules", "laup.mdc")],
+      "claude-code": [join(outputDir, "CLAUDE.md")],
+      aider: [join(outputDir, ".aider.conf.yml"), join(outputDir, "CONVENTIONS.md")],
+    };
+
+    if (conventions[toolId]) {
+      return conventions[toolId];
+    }
+
+    // Generic fallback
+    return Array.from({ length: count }, (_, i) => join(outputDir, `${toolId}-output-${i}`));
   }
 }
 

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -28,4 +28,11 @@ export interface ToolAdapter {
    * Returns the list of file paths written.
    */
   write(rendered: string | string[], targetDir: string): string[];
+
+  /**
+   * Get expected output paths without writing (CONF-020).
+   * Used for diff preview to locate existing files.
+   * Default implementation can be derived from write() conventions.
+   */
+  getOutputPaths?(targetDir: string): string[];
 }


### PR DESCRIPTION
## Summary
Implements CONF-020: dry-run propagation with per-tool diff report.

## Changes
- Add `diff.ts` with LCS-based line diff algorithm
- Add `previewWithDiff()` to SyncEngine for comparing rendered output vs existing files
- Add `getOutputPaths()` to adapter interface for path inference
- Add `--diff` CLI flag to show what would change

## Usage
```bash
laup sync --source laup.md --dry-run --diff
```

Shows NEW/MODIFIED/UNCHANGED status per file with unified diff format.

## Testing
- All 136 tests passing

Closes #23