### PR TITLE
feat(core): define portable skill schema + versioning — SKILL-001, SKILL-003

### DIFF
--- a/packages/core/src/__tests__/skill-schema.test.ts
+++ b/packages/core/src/__tests__/skill-schema.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { parseSkill, renderSkillPrompt, type Skill, validateSkill } from "../skill-schema.js";
+
+describe("skill-schema", () => {
+  const validSkill: Skill = {
+    schemaVersion: "1.0",
+    name: "code-review",
+    version: "1.0.0",
+    description: "Review code for best practices and issues",
+    parameters: [
+      {
+        name: "language",
+        description: "Programming language",
+        type: "string",
+        required: true,
+      },
+      {
+        name: "focus",
+        description: "Review focus area",
+        type: "selection",
+        required: false,
+        options: ["security", "performance", "maintainability"],
+        default: "maintainability",
+      },
+    ],
+    trigger: {
+      command: "/review",
+      aliases: ["code review", "review code"],
+    },
+    prompt: "Review this {{language}} code with focus on {{focus}}:\n\n{{code}}",
+    metadata: {
+      author: "laup",
+      tags: ["code", "review"],
+    },
+  };
+
+  describe("validateSkill", () => {
+    it("validates a correct skill", () => {
+      const result = validateSkill(validSkill);
+      expect(result.valid).toBe(true);
+      expect(result.skill).toBeDefined();
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it("rejects skill without name", () => {
+      const { name, ...skillWithoutName } = validSkill;
+      const result = validateSkill(skillWithoutName);
+      expect(result.valid).toBe(false);
+      expect(result.issues.some((i) => i.path === "name")).toBe(true);
+    });
+
+    it("rejects skill without version", () => {
+      const { version, ...skillWithoutVersion } = validSkill;
+      const result = validateSkill(skillWithoutVersion);
+      expect(result.valid).toBe(false);
+      expect(result.issues.some((i) => i.path === "version")).toBe(true);
+    });
+
+    it("rejects invalid version format", () => {
+      const result = validateSkill({ ...validSkill, version: "1.0" });
+      expect(result.valid).toBe(false);
+      expect(result.issues.some((i) => i.message.includes("semver"))).toBe(true);
+    });
+
+    it("rejects invalid trigger command", () => {
+      const result = validateSkill({
+        ...validSkill,
+        trigger: { command: "review" }, // missing /
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    it("accepts namespaced skill names", () => {
+      const result = validateSkill({
+        ...validSkill,
+        name: "myorg/code-review",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("accepts prerelease versions", () => {
+      const result = validateSkill({
+        ...validSkill,
+        version: "1.0.0-beta.1",
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("validates parameter types", () => {
+      const result = validateSkill({
+        ...validSkill,
+        parameters: [
+          { name: "count", type: "number", required: true },
+          { name: "enabled", type: "boolean", required: false },
+          { name: "items", type: "array", items: "string", required: false },
+        ],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("parseSkill", () => {
+    it("parses valid JSON skill", () => {
+      const json = JSON.stringify(validSkill);
+      const skill = parseSkill(json);
+      expect(skill.name).toBe("code-review");
+    });
+
+    it("parses valid YAML skill", () => {
+      const yaml = `
+schemaVersion: "1.0"
+name: test-skill
+version: 1.0.0
+description: A test skill
+trigger:
+  command: /test
+prompt: Hello {{name}}
+`;
+      const skill = parseSkill(yaml);
+      expect(skill.name).toBe("test-skill");
+    });
+
+    it("throws on invalid skill", () => {
+      expect(() => parseSkill('{"name": "invalid"}')).toThrow("Invalid skill");
+    });
+  });
+
+  describe("renderSkillPrompt", () => {
+    it("substitutes parameters", () => {
+      const skill: Skill = {
+        schemaVersion: "1.0",
+        name: "greet",
+        version: "1.0.0",
+        description: "Greeting skill",
+        parameters: [{ name: "name", type: "string", required: true }],
+        trigger: { command: "/greet" },
+        prompt: "Hello, {{name}}!",
+      };
+
+      const result = renderSkillPrompt(skill, { name: "World" });
+      expect(result).toBe("Hello, World!");
+    });
+
+    it("uses default values", () => {
+      const skill: Skill = {
+        schemaVersion: "1.0",
+        name: "greet",
+        version: "1.0.0",
+        description: "Greeting skill",
+        parameters: [{ name: "name", type: "string", required: false, default: "friend" }],
+        trigger: { command: "/greet" },
+        prompt: "Hello, {{name}}!",
+      };
+
+      const result = renderSkillPrompt(skill, {});
+      expect(result).toBe("Hello, friend!");
+    });
+
+    it("throws on missing required parameter", () => {
+      const skill: Skill = {
+        schemaVersion: "1.0",
+        name: "greet",
+        version: "1.0.0",
+        description: "Greeting skill",
+        parameters: [{ name: "name", type: "string", required: true }],
+        trigger: { command: "/greet" },
+        prompt: "Hello, {{name}}!",
+      };
+
+      expect(() => renderSkillPrompt(skill, {})).toThrow("Missing required parameter");
+    });
+
+    it("handles multiple parameters", () => {
+      const skill: Skill = {
+        schemaVersion: "1.0",
+        name: "template",
+        version: "1.0.0",
+        description: "Template skill",
+        parameters: [
+          { name: "a", type: "string", required: true },
+          { name: "b", type: "string", required: true },
+        ],
+        trigger: { command: "/template" },
+        prompt: "{{a}} and {{b}} together: {{a}}{{b}}",
+      };
+
+      const result = renderSkillPrompt(skill, { a: "X", b: "Y" });
+      expect(result).toBe("X and Y together: XY");
+    });
+  });
+});

--- a/packages/core/src/__tests__/skill-version.test.ts
+++ b/packages/core/src/__tests__/skill-version.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareVersions,
+  findLatestSatisfying,
+  parseConstraint,
+  parseVersion,
+  satisfies,
+  sortVersionsDesc,
+} from "../skill-version.js";
+
+describe("skill-version", () => {
+  describe("parseVersion", () => {
+    it("parses basic version", () => {
+      const v = parseVersion("1.2.3");
+      expect(v).toEqual({ major: 1, minor: 2, patch: 3 });
+    });
+
+    it("parses version with prerelease", () => {
+      const v = parseVersion("1.2.3-beta.1");
+      expect(v).toEqual({ major: 1, minor: 2, patch: 3, prerelease: "beta.1" });
+    });
+
+    it("returns null for invalid version", () => {
+      expect(parseVersion("1.2")).toBeNull();
+      expect(parseVersion("invalid")).toBeNull();
+    });
+  });
+
+  describe("compareVersions", () => {
+    it("compares major versions", () => {
+      expect(compareVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+      expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    });
+
+    it("compares minor versions", () => {
+      expect(compareVersions("1.2.0", "1.1.0")).toBeGreaterThan(0);
+      expect(compareVersions("1.1.0", "1.2.0")).toBeLessThan(0);
+    });
+
+    it("compares patch versions", () => {
+      expect(compareVersions("1.0.2", "1.0.1")).toBeGreaterThan(0);
+      expect(compareVersions("1.0.1", "1.0.2")).toBeLessThan(0);
+    });
+
+    it("compares equal versions", () => {
+      expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    });
+
+    it("prerelease is less than release", () => {
+      expect(compareVersions("1.0.0-beta", "1.0.0")).toBeLessThan(0);
+      expect(compareVersions("1.0.0", "1.0.0-beta")).toBeGreaterThan(0);
+    });
+  });
+
+  describe("parseConstraint", () => {
+    it("parses exact version", () => {
+      expect(parseConstraint("1.0.0")).toEqual({ type: "exact", version: "1.0.0" });
+    });
+
+    it("parses caret constraint", () => {
+      expect(parseConstraint("^1.2.3")).toEqual({ type: "caret", version: "1.2.3" });
+    });
+
+    it("parses tilde constraint", () => {
+      expect(parseConstraint("~1.2.3")).toEqual({ type: "tilde", version: "1.2.3" });
+    });
+
+    it("parses any constraint", () => {
+      expect(parseConstraint("*")).toEqual({ type: "any" });
+      expect(parseConstraint("latest")).toEqual({ type: "any" });
+    });
+
+    it("parses greater than or equal", () => {
+      expect(parseConstraint(">=1.0.0")).toEqual({
+        type: "range",
+        min: "1.0.0",
+        minInclusive: true,
+      });
+    });
+
+    it("parses less than", () => {
+      expect(parseConstraint("<2.0.0")).toEqual({
+        type: "range",
+        max: "2.0.0",
+        maxInclusive: false,
+      });
+    });
+  });
+
+  describe("satisfies", () => {
+    it("exact constraint", () => {
+      expect(satisfies("1.0.0", "1.0.0")).toBe(true);
+      expect(satisfies("1.0.1", "1.0.0")).toBe(false);
+    });
+
+    it("any constraint", () => {
+      expect(satisfies("1.0.0", "*")).toBe(true);
+      expect(satisfies("99.99.99", "*")).toBe(true);
+    });
+
+    it("caret constraint", () => {
+      expect(satisfies("1.2.3", "^1.2.3")).toBe(true);
+      expect(satisfies("1.9.9", "^1.2.3")).toBe(true);
+      expect(satisfies("1.2.4", "^1.2.3")).toBe(true);
+      expect(satisfies("2.0.0", "^1.2.3")).toBe(false);
+      expect(satisfies("1.2.2", "^1.2.3")).toBe(false);
+    });
+
+    it("tilde constraint", () => {
+      expect(satisfies("1.2.3", "~1.2.3")).toBe(true);
+      expect(satisfies("1.2.9", "~1.2.3")).toBe(true);
+      expect(satisfies("1.3.0", "~1.2.3")).toBe(false);
+      expect(satisfies("1.2.2", "~1.2.3")).toBe(false);
+    });
+
+    it("greater than or equal", () => {
+      expect(satisfies("1.0.0", ">=1.0.0")).toBe(true);
+      expect(satisfies("2.0.0", ">=1.0.0")).toBe(true);
+      expect(satisfies("0.9.9", ">=1.0.0")).toBe(false);
+    });
+
+    it("less than", () => {
+      expect(satisfies("1.9.9", "<2.0.0")).toBe(true);
+      expect(satisfies("2.0.0", "<2.0.0")).toBe(false);
+    });
+  });
+
+  describe("findLatestSatisfying", () => {
+    const versions = ["1.0.0", "1.1.0", "1.2.0", "2.0.0", "2.1.0"];
+
+    it("finds latest for any", () => {
+      expect(findLatestSatisfying(versions, "*")).toBe("2.1.0");
+    });
+
+    it("finds latest for caret", () => {
+      expect(findLatestSatisfying(versions, "^1.0.0")).toBe("1.2.0");
+    });
+
+    it("finds latest for tilde", () => {
+      expect(findLatestSatisfying(["1.0.0", "1.0.1", "1.0.2", "1.1.0"], "~1.0.0")).toBe("1.0.2");
+    });
+
+    it("returns null when no match", () => {
+      expect(findLatestSatisfying(versions, "3.0.0")).toBeNull();
+    });
+  });
+
+  describe("sortVersionsDesc", () => {
+    it("sorts versions in descending order", () => {
+      const versions = ["1.0.0", "2.1.0", "1.2.0", "2.0.0"];
+      expect(sortVersionsDesc(versions)).toEqual(["2.1.0", "2.0.0", "1.2.0", "1.0.0"]);
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,5 +13,35 @@ export type { Scope, ScopedDocument } from "./scope.js";
 export { mergeScopes, SCOPE_PRECEDENCE, scopePrecedence } from "./scope.js";
 export type { ScopeConfig, ScopeLoadResult } from "./scope-loader.js";
 export { getDefaultScopePath, loadScopedDocument, loadScopes } from "./scope-loader.js";
+export type {
+  Skill,
+  SkillMetadata,
+  SkillParameter,
+  SkillParameterType,
+  SkillToolOverride,
+  SkillTrigger,
+  SkillValidationResult,
+} from "./skill-schema.js";
+export {
+  parseSkill,
+  renderSkillPrompt,
+  SkillMetadataSchema,
+  SkillParameterSchema,
+  SkillParameterTypeSchema,
+  SkillSchema,
+  SkillToolOverrideSchema,
+  SkillTriggerSchema,
+  validateSkill,
+} from "./skill-schema.js";
+export type { SemanticVersion, VersionConstraint } from "./skill-version.js";
+export {
+  compareVersions,
+  findLatestSatisfying,
+  parseConstraint,
+  parseVersion,
+  satisfies,
+  satisfiesConstraint,
+  sortVersionsDesc,
+} from "./skill-version.js";
 export type { ValidationIssue, ValidationResult } from "./validate.js";
 export { validateCanonical } from "./validate.js";

--- a/packages/core/src/skill-schema.ts
+++ b/packages/core/src/skill-schema.ts
@@ -1,0 +1,249 @@
+import { z } from "zod";
+
+/**
+ * Portable Skill Schema (SKILL-001)
+ *
+ * Defines a tool-agnostic skill format for reusable prompt templates.
+ * Skills can be rendered to tool-specific formats by skill adapters.
+ */
+
+/**
+ * Parameter type for skill inputs.
+ */
+export const SkillParameterTypeSchema = z.enum([
+  "string",
+  "number",
+  "boolean",
+  "array",
+  "object",
+  "file",
+  "selection",
+]);
+
+export type SkillParameterType = z.infer<typeof SkillParameterTypeSchema>;
+
+/**
+ * Skill parameter definition with type information and constraints.
+ */
+export const SkillParameterSchema = z.object({
+  /** Parameter name (used in template substitution) */
+  name: z.string().min(1),
+
+  /** Human-readable description of the parameter */
+  description: z.string().optional(),
+
+  /** Parameter type */
+  type: SkillParameterTypeSchema,
+
+  /** Whether this parameter is required */
+  required: z.boolean().default(true),
+
+  /** Default value if not provided */
+  default: z.unknown().optional(),
+
+  /** For selection type: allowed values */
+  options: z.array(z.string()).optional(),
+
+  /** For array type: item type */
+  items: SkillParameterTypeSchema.optional(),
+
+  /** For string type: regex pattern */
+  pattern: z.string().optional(),
+
+  /** For number type: minimum value */
+  min: z.number().optional(),
+
+  /** For number type: maximum value */
+  max: z.number().optional(),
+});
+
+export type SkillParameter = z.infer<typeof SkillParameterSchema>;
+
+/**
+ * Invocation trigger for the skill.
+ */
+export const SkillTriggerSchema = z.object({
+  /** Slash command to invoke the skill (e.g., "/review") */
+  command: z
+    .string()
+    .regex(/^\/[a-z][a-z0-9-]*$/i, "Command must start with / and be alphanumeric"),
+
+  /** Keyboard shortcut (optional, tool-specific rendering) */
+  shortcut: z.string().optional(),
+
+  /** Natural language aliases for discovery */
+  aliases: z.array(z.string()).optional(),
+});
+
+export type SkillTrigger = z.infer<typeof SkillTriggerSchema>;
+
+/**
+ * Skill metadata.
+ */
+export const SkillMetadataSchema = z.object({
+  /** Author name or organization */
+  author: z.string().optional(),
+
+  /** License identifier (e.g., "MIT", "Apache-2.0") */
+  license: z.string().optional(),
+
+  /** Homepage URL */
+  homepage: z.string().url().optional(),
+
+  /** Repository URL */
+  repository: z.string().url().optional(),
+
+  /** Tags for categorization and discovery */
+  tags: z.array(z.string()).optional(),
+
+  /** Date the skill was created */
+  created: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be ISO 8601 format YYYY-MM-DD")
+    .optional(),
+
+  /** Date the skill was last updated */
+  updated: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be ISO 8601 format YYYY-MM-DD")
+    .optional(),
+});
+
+export type SkillMetadata = z.infer<typeof SkillMetadataSchema>;
+
+/**
+ * Tool-specific override for skill rendering.
+ */
+export const SkillToolOverrideSchema = z.record(z.string(), z.unknown());
+
+export type SkillToolOverride = z.infer<typeof SkillToolOverrideSchema>;
+
+/**
+ * Portable skill definition.
+ */
+export const SkillSchema = z.object({
+  /** Schema version for the skill format */
+  schemaVersion: z
+    .string()
+    .regex(/^\d+\.\d+$/, "Schema version must match pattern N.N")
+    .default("1.0"),
+
+  /** Unique skill name (namespace/name format recommended) */
+  name: z
+    .string()
+    .min(1)
+    .regex(
+      /^[a-z][a-z0-9-]*(?:\/[a-z][a-z0-9-]*)?$/i,
+      "Name must be alphanumeric with optional namespace",
+    ),
+
+  /** Semantic version of the skill */
+  version: z.string().regex(/^\d+\.\d+\.\d+(?:-[a-z0-9.]+)?$/i, "Version must be semver format"),
+
+  /** Human-readable description */
+  description: z.string(),
+
+  /** Parameter definitions */
+  parameters: z.array(SkillParameterSchema).default([]),
+
+  /** Invocation trigger */
+  trigger: SkillTriggerSchema,
+
+  /** Prompt template body (supports {{parameter}} substitution) */
+  prompt: z.string().min(1),
+
+  /** Optional system prompt prefix */
+  system: z.string().optional(),
+
+  /** Output format hint */
+  outputFormat: z.enum(["text", "markdown", "json", "code"]).optional(),
+
+  /** Skill metadata */
+  metadata: SkillMetadataSchema.optional(),
+
+  /** Tool-specific overrides */
+  tools: z.record(z.string(), SkillToolOverrideSchema).optional(),
+});
+
+export type Skill = z.infer<typeof SkillSchema>;
+
+/**
+ * Validate a skill definition.
+ */
+export interface SkillValidationResult {
+  valid: boolean;
+  skill?: Skill;
+  issues: Array<{
+    path: string;
+    message: string;
+  }>;
+}
+
+/**
+ * Validate a skill object against the schema.
+ */
+export function validateSkill(skill: unknown): SkillValidationResult {
+  const result = SkillSchema.safeParse(skill);
+
+  if (result.success) {
+    return {
+      valid: true,
+      skill: result.data,
+      issues: [],
+    };
+  }
+
+  return {
+    valid: false,
+    issues: result.error.issues.map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+    })),
+  };
+}
+
+/**
+ * Parse and validate a skill from YAML/JSON content.
+ */
+export function parseSkill(content: string): Skill {
+  // Try JSON first
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    // Try YAML
+    const { load } = require("js-yaml");
+    parsed = load(content);
+  }
+
+  const result = validateSkill(parsed);
+  if (!result.valid) {
+    const messages = result.issues.map((i) => `${i.path}: ${i.message}`).join("; ");
+    throw new Error(`Invalid skill: ${messages}`);
+  }
+
+  return result.skill!;
+}
+
+/**
+ * Substitute parameters into a skill prompt.
+ */
+export function renderSkillPrompt(skill: Skill, params: Record<string, unknown> = {}): string {
+  let prompt = skill.prompt;
+
+  // Validate required parameters
+  for (const param of skill.parameters) {
+    if (param.required && !(param.name in params) && param.default === undefined) {
+      throw new Error(`Missing required parameter: ${param.name}`);
+    }
+  }
+
+  // Substitute parameters
+  for (const param of skill.parameters) {
+    const value = params[param.name] ?? param.default ?? "";
+    const placeholder = `{{${param.name}}}`;
+    prompt = prompt.replaceAll(placeholder, String(value));
+  }
+
+  return prompt;
+}

--- a/packages/core/src/skill-version.ts
+++ b/packages/core/src/skill-version.ts
@@ -1,0 +1,209 @@
+/**
+ * Semantic versioning utilities for skills (SKILL-003).
+ */
+
+export interface SemanticVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+}
+
+/**
+ * Parse a semver string into components.
+ */
+export function parseVersion(version: string): SemanticVersion | null {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([a-z0-9.]+))?$/i);
+  if (!match) return null;
+
+  const result: SemanticVersion = {
+    major: Number.parseInt(match[1] ?? "0", 10),
+    minor: Number.parseInt(match[2] ?? "0", 10),
+    patch: Number.parseInt(match[3] ?? "0", 10),
+  };
+
+  if (match[4]) {
+    result.prerelease = match[4];
+  }
+
+  return result;
+}
+
+/**
+ * Compare two versions. Returns:
+ * - negative if a < b
+ * - 0 if a === b
+ * - positive if a > b
+ */
+export function compareVersions(a: string, b: string): number {
+  const va = parseVersion(a);
+  const vb = parseVersion(b);
+
+  if (!va || !vb) {
+    throw new Error(`Invalid version: ${!va ? a : b}`);
+  }
+
+  // Compare major.minor.patch
+  if (va.major !== vb.major) return va.major - vb.major;
+  if (va.minor !== vb.minor) return va.minor - vb.minor;
+  if (va.patch !== vb.patch) return va.patch - vb.patch;
+
+  // Prerelease versions have lower precedence
+  if (va.prerelease && !vb.prerelease) return -1;
+  if (!va.prerelease && vb.prerelease) return 1;
+  if (va.prerelease && vb.prerelease) {
+    return va.prerelease.localeCompare(vb.prerelease);
+  }
+
+  return 0;
+}
+
+/**
+ * Version constraint types.
+ */
+export type VersionConstraint =
+  | { type: "exact"; version: string }
+  | { type: "range"; min?: string; max?: string; minInclusive?: boolean; maxInclusive?: boolean }
+  | { type: "caret"; version: string } // ^1.2.3 - compatible with 1.x.x
+  | { type: "tilde"; version: string } // ~1.2.3 - compatible with 1.2.x
+  | { type: "any" };
+
+/**
+ * Parse a version constraint string.
+ * Supports: exact (1.0.0), caret (^1.0.0), tilde (~1.0.0), range (>=1.0.0 <2.0.0), any (*)
+ */
+export function parseConstraint(constraint: string): VersionConstraint {
+  const trimmed = constraint.trim();
+
+  if (trimmed === "*" || trimmed === "latest") {
+    return { type: "any" };
+  }
+
+  if (trimmed.startsWith("^")) {
+    return { type: "caret", version: trimmed.slice(1) };
+  }
+
+  if (trimmed.startsWith("~")) {
+    return { type: "tilde", version: trimmed.slice(1) };
+  }
+
+  // Range: >=1.0.0 <2.0.0
+  const rangeMatch = trimmed.match(
+    /^(>=?)?(\d+\.\d+\.\d+(?:-[a-z0-9.]+)?)\s+(<?=?)(\d+\.\d+\.\d+(?:-[a-z0-9.]+)?)$/i,
+  );
+  if (rangeMatch && rangeMatch[2] && rangeMatch[4]) {
+    return {
+      type: "range",
+      min: rangeMatch[2],
+      max: rangeMatch[4],
+      minInclusive: rangeMatch[1] === ">=" || !rangeMatch[1],
+      maxInclusive: rangeMatch[3] === "<=",
+    };
+  }
+
+  // Single bound: >=1.0.0 or <2.0.0
+  const singleBoundMatch = trimmed.match(/^(>=?|<=?)?(\d+\.\d+\.\d+(?:-[a-z0-9.]+)?)$/i);
+  if (singleBoundMatch && singleBoundMatch[2]) {
+    const op = singleBoundMatch[1];
+    const ver = singleBoundMatch[2];
+
+    if (!op) {
+      return { type: "exact", version: ver };
+    }
+
+    if (op === ">=" || op === ">") {
+      return { type: "range", min: ver, minInclusive: op === ">=" };
+    }
+    if (op === "<=" || op === "<") {
+      return { type: "range", max: ver, maxInclusive: op === "<=" };
+    }
+  }
+
+  // Default to exact match
+  return { type: "exact", version: trimmed };
+}
+
+/**
+ * Check if a version satisfies a constraint.
+ */
+export function satisfiesConstraint(version: string, constraint: VersionConstraint): boolean {
+  const v = parseVersion(version);
+  if (!v) return false;
+
+  switch (constraint.type) {
+    case "any":
+      return true;
+
+    case "exact":
+      return compareVersions(version, constraint.version) === 0;
+
+    case "caret": {
+      // ^1.2.3 means >=1.2.3 <2.0.0 (or <1.0.0 if major is 0)
+      const base = parseVersion(constraint.version);
+      if (!base) return false;
+
+      const cmp = compareVersions(version, constraint.version);
+      if (cmp < 0) return false;
+
+      if (base.major === 0) {
+        // ^0.x.y is more restrictive
+        return v.major === 0 && v.minor === base.minor;
+      }
+      return v.major === base.major;
+    }
+
+    case "tilde": {
+      // ~1.2.3 means >=1.2.3 <1.3.0
+      const base = parseVersion(constraint.version);
+      if (!base) return false;
+
+      const cmp = compareVersions(version, constraint.version);
+      if (cmp < 0) return false;
+
+      return v.major === base.major && v.minor === base.minor;
+    }
+
+    case "range": {
+      if (constraint.min) {
+        const minCmp = compareVersions(version, constraint.min);
+        if (constraint.minInclusive ? minCmp < 0 : minCmp <= 0) {
+          return false;
+        }
+      }
+      if (constraint.max) {
+        const maxCmp = compareVersions(version, constraint.max);
+        if (constraint.maxInclusive ? maxCmp > 0 : maxCmp >= 0) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+}
+
+/**
+ * Check if a version string satisfies a constraint string.
+ */
+export function satisfies(version: string, constraint: string): boolean {
+  return satisfiesConstraint(version, parseConstraint(constraint));
+}
+
+/**
+ * Find the latest version that satisfies a constraint.
+ */
+export function findLatestSatisfying(versions: string[], constraint: string): string | null {
+  const parsed = parseConstraint(constraint);
+  const satisfying = versions.filter((v) => satisfiesConstraint(v, parsed));
+
+  if (satisfying.length === 0) return null;
+
+  const sorted = satisfying.sort(compareVersions).reverse();
+  return sorted[0] ?? null;
+}
+
+/**
+ * Sort versions in descending order (latest first).
+ */
+export function sortVersionsDesc(versions: string[]): string[] {
+  return [...versions].sort(compareVersions).reverse();
+}


### PR DESCRIPTION
## Summary
Implements SKILL-001 (portable skill schema) and SKILL-003 (semantic versioning).

## Skill Schema (SKILL-001)
- `name`: Unique skill identifier (supports namespace/name format)
- `version`: Semver version
- `description`: Human-readable description
- `parameters`: Typed parameter definitions
- `trigger`: Invocation trigger (slash command, aliases)
- `prompt`: Template body with {{param}} substitution
- `metadata`: Author, license, tags, dates
- `tools`: Tool-specific overrides

## Version Utilities (SKILL-003)
- `parseVersion()`: Parse semver string
- `compareVersions()`: Compare two versions
- `parseConstraint()`: Parse version constraints (^, ~, >=, <, *)
- `satisfies()`: Check if version matches constraint
- `findLatestSatisfying()`: Find latest version matching constraint

## Testing
- 40 new tests (15 schema + 25 versioning)
- 176 total tests passing

Closes #24, Closes #26