### PR TITLE
feat(core): implement skill renderers for all tools — SKILL-002

### DIFF
--- a/packages/core/src/__tests__/skill-renderer.test.ts
+++ b/packages/core/src/__tests__/skill-renderer.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  AiderSkillRenderer,
+  ClaudeCodeSkillRenderer,
+  CursorSkillRenderer,
+  getSkillRenderer,
+  renderSkillToAllTools,
+} from "../skill-renderer.js";
+import type { Skill } from "../skill-schema.js";
+
+const sampleSkill: Skill = {
+  schemaVersion: "1.0",
+  name: "code-review",
+  version: "1.0.0",
+  description: "Review code for best practices and issues",
+  parameters: [
+    {
+      name: "language",
+      description: "Programming language",
+      type: "string",
+      required: true,
+    },
+    {
+      name: "focus",
+      description: "Review focus area",
+      type: "selection",
+      required: false,
+      options: ["security", "performance", "maintainability"],
+      default: "maintainability",
+    },
+  ],
+  trigger: {
+    command: "/review",
+    aliases: ["code review", "review code"],
+  },
+  prompt: "Review this {{language}} code with focus on {{focus}}:\n\n{{code}}",
+  system: "You are a senior code reviewer.",
+  metadata: {
+    author: "laup",
+    license: "MIT",
+    tags: ["code", "review"],
+  },
+};
+
+describe("skill-renderer", () => {
+  describe("ClaudeCodeSkillRenderer", () => {
+    const renderer = new ClaudeCodeSkillRenderer();
+
+    it("renders skill as markdown", () => {
+      const output = renderer.render(sampleSkill);
+
+      expect(output).toContain("# code-review");
+      expect(output).toContain("Review code for best practices");
+      expect(output).toContain("`/review`");
+      expect(output).toContain("Aliases: code review, review code");
+      expect(output).toContain("**language** `string` (required)");
+      expect(output).toContain("**focus** `selection` (optional)");
+      expect(output).toContain("You are a senior code reviewer");
+      expect(output).toContain("{{language}}");
+    });
+
+    it("generates correct filename", () => {
+      const filename = renderer.getFilename(sampleSkill);
+      expect(filename).toBe("skill-code-review.md");
+    });
+
+    it("handles skill without optional fields", () => {
+      const minimalSkill: Skill = {
+        schemaVersion: "1.0",
+        name: "simple",
+        version: "1.0.0",
+        description: "A simple skill",
+        parameters: [],
+        trigger: { command: "/simple" },
+        prompt: "Do something simple",
+      };
+
+      const output = renderer.render(minimalSkill);
+      expect(output).toContain("# simple");
+      expect(output).toContain("Do something simple");
+      expect(output).not.toContain("## Parameters");
+    });
+  });
+
+  describe("CursorSkillRenderer", () => {
+    const renderer = new CursorSkillRenderer();
+
+    it("renders skill as MDC with frontmatter", () => {
+      const output = renderer.render(sampleSkill);
+
+      expect(output).toContain("---");
+      expect(output).toContain('description: "Review code for best practices');
+      expect(output).toContain("# code-review");
+      expect(output).toContain("**Trigger:** `/review`");
+      expect(output).toContain("`{{language}}`");
+    });
+
+    it("includes cursor-specific overrides", () => {
+      const skillWithOverrides: Skill = {
+        ...sampleSkill,
+        tools: {
+          cursor: {
+            globs: ["**/*.ts", "**/*.tsx"],
+            alwaysApply: true,
+          },
+        },
+      };
+
+      const output = renderer.render(skillWithOverrides);
+      expect(output).toContain("globs:");
+      expect(output).toContain('"**/*.ts"');
+      expect(output).toContain("alwaysApply: true");
+    });
+
+    it("generates correct filename", () => {
+      const filename = renderer.getFilename(sampleSkill);
+      expect(filename).toBe("code-review.mdc");
+    });
+  });
+
+  describe("AiderSkillRenderer", () => {
+    const renderer = new AiderSkillRenderer();
+
+    it("renders skill as markdown", () => {
+      const output = renderer.render(sampleSkill);
+
+      expect(output).toContain("# Skill: code-review");
+      expect(output).toContain("Use `/review` to invoke");
+      expect(output).toContain("**language** (string, required)");
+      expect(output).toContain("Default: `maintainability`");
+    });
+
+    it("generates correct filename", () => {
+      const filename = renderer.getFilename(sampleSkill);
+      expect(filename).toBe("SKILL-CODE-REVIEW.md");
+    });
+  });
+
+  describe("getSkillRenderer", () => {
+    it("returns renderer for known tool", () => {
+      expect(getSkillRenderer("claude-code")).toBeInstanceOf(ClaudeCodeSkillRenderer);
+      expect(getSkillRenderer("cursor")).toBeInstanceOf(CursorSkillRenderer);
+      expect(getSkillRenderer("aider")).toBeInstanceOf(AiderSkillRenderer);
+    });
+
+    it("returns undefined for unknown tool", () => {
+      expect(getSkillRenderer("unknown-tool")).toBeUndefined();
+    });
+  });
+
+  describe("renderSkillToAllTools", () => {
+    it("renders skill to all tools", () => {
+      const results = renderSkillToAllTools(sampleSkill);
+
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.toolId).sort()).toEqual(["aider", "claude-code", "cursor"]);
+
+      for (const result of results) {
+        expect(result.filename).toBeTruthy();
+        expect(result.content).toBeTruthy();
+        expect(result.content).toContain("code-review");
+      }
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,15 @@ export type { Scope, ScopedDocument } from "./scope.js";
 export { mergeScopes, SCOPE_PRECEDENCE, scopePrecedence } from "./scope.js";
 export type { ScopeConfig, ScopeLoadResult } from "./scope-loader.js";
 export { getDefaultScopePath, loadScopedDocument, loadScopes } from "./scope-loader.js";
+export type { SkillRenderer } from "./skill-renderer.js";
+export {
+  AiderSkillRenderer,
+  ClaudeCodeSkillRenderer,
+  CursorSkillRenderer,
+  getSkillRenderer,
+  renderSkillToAllTools,
+  skillRenderers,
+} from "./skill-renderer.js";
 export type {
   Skill,
   SkillMetadata,

--- a/packages/core/src/skill-renderer.ts
+++ b/packages/core/src/skill-renderer.ts
@@ -1,0 +1,264 @@
+import type { Skill } from "./skill-schema.js";
+
+/**
+ * Skill renderer interface (SKILL-002).
+ * Compiles a portable skill into a tool's native format.
+ */
+export interface SkillRenderer {
+  /** Tool ID this renderer targets */
+  readonly toolId: string;
+
+  /** Human-readable tool name */
+  readonly displayName: string;
+
+  /**
+   * Render a skill to the tool's native format.
+   * Returns the rendered content as a string.
+   */
+  render(skill: Skill): string;
+
+  /**
+   * Get the filename for the rendered skill.
+   */
+  getFilename(skill: Skill): string;
+}
+
+/**
+ * Claude Code skill renderer.
+ * Renders skills as markdown with slash command documentation.
+ */
+export class ClaudeCodeSkillRenderer implements SkillRenderer {
+  readonly toolId = "claude-code";
+  readonly displayName = "Claude Code";
+
+  render(skill: Skill): string {
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`# ${skill.name}`);
+    lines.push("");
+    lines.push(skill.description);
+    lines.push("");
+
+    // Trigger
+    lines.push(`## Trigger`);
+    lines.push("");
+    lines.push(`\`${skill.trigger.command}\``);
+    if (skill.trigger.aliases && skill.trigger.aliases.length > 0) {
+      lines.push("");
+      lines.push(`Aliases: ${skill.trigger.aliases.join(", ")}`);
+    }
+    lines.push("");
+
+    // Parameters
+    if (skill.parameters.length > 0) {
+      lines.push("## Parameters");
+      lines.push("");
+      for (const param of skill.parameters) {
+        const required = param.required ? "(required)" : "(optional)";
+        const defaultVal = param.default !== undefined ? ` [default: ${param.default}]` : "";
+        lines.push(`- **${param.name}** \`${param.type}\` ${required}${defaultVal}`);
+        if (param.description) {
+          lines.push(`  ${param.description}`);
+        }
+        if (param.options) {
+          lines.push(`  Options: ${param.options.join(", ")}`);
+        }
+      }
+      lines.push("");
+    }
+
+    // Prompt template
+    lines.push("## Prompt");
+    lines.push("");
+    if (skill.system) {
+      lines.push("**System:**");
+      lines.push("```");
+      lines.push(skill.system);
+      lines.push("```");
+      lines.push("");
+    }
+    lines.push("**User:**");
+    lines.push("```");
+    lines.push(skill.prompt);
+    lines.push("```");
+    lines.push("");
+
+    // Metadata
+    if (skill.metadata) {
+      lines.push("## Metadata");
+      lines.push("");
+      if (skill.metadata.author) {
+        lines.push(`- Author: ${skill.metadata.author}`);
+      }
+      if (skill.metadata.license) {
+        lines.push(`- License: ${skill.metadata.license}`);
+      }
+      if (skill.metadata.tags && skill.metadata.tags.length > 0) {
+        lines.push(`- Tags: ${skill.metadata.tags.join(", ")}`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n").trimEnd();
+  }
+
+  getFilename(skill: Skill): string {
+    const safeName = skill.name.replace(/[^a-z0-9-]/gi, "-");
+    return `skill-${safeName}.md`;
+  }
+}
+
+/**
+ * Cursor skill renderer.
+ * Renders skills as MDC files with YAML frontmatter.
+ */
+export class CursorSkillRenderer implements SkillRenderer {
+  readonly toolId = "cursor";
+  readonly displayName = "Cursor";
+
+  render(skill: Skill): string {
+    const lines: string[] = [];
+
+    // YAML frontmatter
+    lines.push("---");
+    lines.push(`description: "${skill.description.replace(/"/g, '\\"')}"`);
+    if (skill.tools?.["cursor"]) {
+      const cursorOverrides = skill.tools["cursor"] as Record<string, unknown>;
+      if (cursorOverrides["globs"]) {
+        lines.push("globs:");
+        for (const glob of cursorOverrides["globs"] as string[]) {
+          lines.push(`  - "${glob}"`);
+        }
+      }
+      if (cursorOverrides["alwaysApply"] !== undefined) {
+        lines.push(`alwaysApply: ${cursorOverrides["alwaysApply"]}`);
+      }
+    }
+    lines.push("---");
+    lines.push("");
+
+    // Title and description
+    lines.push(`# ${skill.name}`);
+    lines.push("");
+    lines.push(`**Trigger:** \`${skill.trigger.command}\``);
+    lines.push("");
+
+    // Parameters as structured instructions
+    if (skill.parameters.length > 0) {
+      lines.push("## Parameters");
+      lines.push("");
+      for (const param of skill.parameters) {
+        const required = param.required ? "required" : "optional";
+        lines.push(
+          `- \`{{${param.name}}}\`: ${param.description || param.name} (${required}, ${param.type})`,
+        );
+      }
+      lines.push("");
+    }
+
+    // Prompt
+    lines.push("## Instructions");
+    lines.push("");
+    if (skill.system) {
+      lines.push(skill.system);
+      lines.push("");
+    }
+    lines.push(skill.prompt);
+
+    return lines.join("\n").trimEnd();
+  }
+
+  getFilename(skill: Skill): string {
+    const safeName = skill.name.replace(/[^a-z0-9-]/gi, "-");
+    return `${safeName}.mdc`;
+  }
+}
+
+/**
+ * Aider skill renderer.
+ * Renders skills as markdown convention files.
+ */
+export class AiderSkillRenderer implements SkillRenderer {
+  readonly toolId = "aider";
+  readonly displayName = "Aider";
+
+  render(skill: Skill): string {
+    const lines: string[] = [];
+
+    // Header
+    lines.push(`# Skill: ${skill.name}`);
+    lines.push("");
+    lines.push(skill.description);
+    lines.push("");
+
+    // Trigger
+    lines.push(`## Invocation`);
+    lines.push("");
+    lines.push(`Use \`${skill.trigger.command}\` to invoke this skill.`);
+    lines.push("");
+
+    // Parameters
+    if (skill.parameters.length > 0) {
+      lines.push("## Parameters");
+      lines.push("");
+      lines.push("When invoking, provide these parameters:");
+      lines.push("");
+      for (const param of skill.parameters) {
+        const required = param.required ? "required" : "optional";
+        lines.push(`- **${param.name}** (${param.type}, ${required}): ${param.description || ""}`);
+        if (param.default !== undefined) {
+          lines.push(`  Default: \`${param.default}\``);
+        }
+      }
+      lines.push("");
+    }
+
+    // Instructions
+    lines.push("## Instructions");
+    lines.push("");
+    if (skill.system) {
+      lines.push(skill.system);
+      lines.push("");
+    }
+    lines.push(skill.prompt);
+
+    return lines.join("\n").trimEnd();
+  }
+
+  getFilename(skill: Skill): string {
+    const safeName = skill.name.replace(/[^a-z0-9-]/gi, "-");
+    return `SKILL-${safeName.toUpperCase()}.md`;
+  }
+}
+
+/**
+ * Registry of skill renderers.
+ */
+export const skillRenderers: Record<string, SkillRenderer> = {
+  "claude-code": new ClaudeCodeSkillRenderer(),
+  cursor: new CursorSkillRenderer(),
+  aider: new AiderSkillRenderer(),
+};
+
+/**
+ * Get a skill renderer by tool ID.
+ */
+export function getSkillRenderer(toolId: string): SkillRenderer | undefined {
+  return skillRenderers[toolId];
+}
+
+/**
+ * Render a skill to all supported tools.
+ */
+export function renderSkillToAllTools(skill: Skill): Array<{
+  toolId: string;
+  filename: string;
+  content: string;
+}> {
+  return Object.values(skillRenderers).map((renderer) => ({
+    toolId: renderer.toolId,
+    filename: renderer.getFilename(skill),
+    content: renderer.render(skill),
+  }));
+}


### PR DESCRIPTION
## Summary
Implements SKILL-002: skill renderers that compile portable skills to tool-native formats.

## Renderers
- **ClaudeCodeSkillRenderer**: Markdown with slash command docs
- **CursorSkillRenderer**: MDC with YAML frontmatter
- **AiderSkillRenderer**: Markdown convention files

## API
- `getSkillRenderer(toolId)`: Get renderer by tool ID
- `renderSkillToAllTools(skill)`: Render to all supported tools

## Testing
- 11 new tests, 187 total passing

Closes #25