### PR TITLE
feat(core): add skill namespace isolation — SKILL-007

### DIFF
--- a/packages/core/src/__tests__/skill-schema.test.ts
+++ b/packages/core/src/__tests__/skill-schema.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 import {
   getDeprecationNotice,
+  isNamespacedSkill,
   isSkillDeprecated,
   parseSkill,
+  parseSkillName,
+  qualifySkillName,
   renderSkillPrompt,
   type Skill,
+  skillBelongsToNamespace,
+  skillNamesEqual,
   validateSkill,
+  validateSkillNamespace,
 } from "../skill-schema.js";
 
 describe("skill-schema", () => {
@@ -273,6 +279,74 @@ prompt: Hello {{name}}
         },
       });
       expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("namespace isolation (SKILL-007)", () => {
+    it("parseSkillName parses namespaced skill", () => {
+      const result = parseSkillName("acme-corp/code-review");
+      expect(result.namespace).toBe("acme-corp");
+      expect(result.name).toBe("code-review");
+      expect(result.fullName).toBe("acme-corp/code-review");
+    });
+
+    it("parseSkillName parses unnamespaced skill", () => {
+      const result = parseSkillName("code-review");
+      expect(result.namespace).toBeUndefined();
+      expect(result.name).toBe("code-review");
+      expect(result.fullName).toBe("code-review");
+    });
+
+    it("isNamespacedSkill returns true for namespaced", () => {
+      expect(isNamespacedSkill("acme/skill")).toBe(true);
+    });
+
+    it("isNamespacedSkill returns false for unnamespaced", () => {
+      expect(isNamespacedSkill("skill")).toBe(false);
+    });
+
+    it("validateSkillNamespace passes for namespaced skill", () => {
+      const skill: Skill = {
+        ...validSkill,
+        name: "acme-corp/code-review",
+      };
+      const result = validateSkillNamespace(skill);
+      expect(result.valid).toBe(true);
+    });
+
+    it("validateSkillNamespace fails for unnamespaced skill", () => {
+      const result = validateSkillNamespace(validSkill);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("must be namespaced");
+    });
+
+    it("validateSkillNamespace fails for invalid namespace", () => {
+      const skill: Skill = {
+        ...validSkill,
+        name: "123invalid/skill",
+      };
+      const result = validateSkillNamespace(skill);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("Invalid namespace");
+    });
+
+    it("qualifySkillName adds namespace to unnamespaced", () => {
+      expect(qualifySkillName("acme", "my-skill")).toBe("acme/my-skill");
+    });
+
+    it("qualifySkillName preserves existing namespace", () => {
+      expect(qualifySkillName("acme", "other/my-skill")).toBe("other/my-skill");
+    });
+
+    it("skillNamesEqual compares case-insensitively", () => {
+      expect(skillNamesEqual("Acme/Skill", "acme/skill")).toBe(true);
+      expect(skillNamesEqual("acme/skill", "other/skill")).toBe(false);
+    });
+
+    it("skillBelongsToNamespace checks namespace ownership", () => {
+      expect(skillBelongsToNamespace("acme/skill", "acme")).toBe(true);
+      expect(skillBelongsToNamespace("acme/skill", "other")).toBe(false);
+      expect(skillBelongsToNamespace("skill", "acme")).toBe(false);
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   Skill,
   SkillDeprecation,
   SkillMetadata,
+  SkillNamespace,
   SkillParameter,
   SkillParameterType,
   SkillToolOverride,
@@ -34,8 +35,11 @@ export type {
 } from "./skill-schema.js";
 export {
   getDeprecationNotice,
+  isNamespacedSkill,
   isSkillDeprecated,
   parseSkill,
+  parseSkillName,
+  qualifySkillName,
   renderSkillPrompt,
   SkillDeprecationSchema,
   SkillMetadataSchema,
@@ -44,7 +48,10 @@ export {
   SkillSchema,
   SkillToolOverrideSchema,
   SkillTriggerSchema,
+  skillBelongsToNamespace,
+  skillNamesEqual,
   validateSkill,
+  validateSkillNamespace,
 } from "./skill-schema.js";
 export type { SemanticVersion, VersionConstraint } from "./skill-version.js";
 export {

--- a/packages/core/src/skill-schema.ts
+++ b/packages/core/src/skill-schema.ts
@@ -311,3 +311,101 @@ export function getDeprecationNotice(skill: Skill): string | null {
 
   return parts.join(" ");
 }
+
+/**
+ * Parsed skill namespace components (SKILL-007).
+ */
+export interface SkillNamespace {
+  /** Organization/owner namespace (undefined if unnamespaced) */
+  namespace?: string;
+  /** Skill name within the namespace */
+  name: string;
+  /** Full qualified name (namespace/name or just name) */
+  fullName: string;
+}
+
+/**
+ * Parse a skill name into namespace components.
+ */
+export function parseSkillName(skillName: string): SkillNamespace {
+  const parts = skillName.split("/");
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    return {
+      namespace: parts[0],
+      name: parts[1],
+      fullName: skillName,
+    };
+  }
+  return {
+    name: skillName,
+    fullName: skillName,
+  };
+}
+
+/**
+ * Check if a skill name is namespaced.
+ */
+export function isNamespacedSkill(skillName: string): boolean {
+  return skillName.includes("/");
+}
+
+/**
+ * Validate that a skill has a namespace (required for publishing).
+ */
+export function validateSkillNamespace(skill: Skill): {
+  valid: boolean;
+  error?: string;
+} {
+  const parsed = parseSkillName(skill.name);
+
+  if (!parsed.namespace) {
+    return {
+      valid: false,
+      error: `Skill "${skill.name}" must be namespaced (e.g., "org-name/${skill.name}") for publishing`,
+    };
+  }
+
+  // Validate namespace format
+  if (!/^[a-z][a-z0-9-]*$/i.test(parsed.namespace)) {
+    return {
+      valid: false,
+      error: `Invalid namespace "${parsed.namespace}": must be alphanumeric with hyphens`,
+    };
+  }
+
+  // Validate name format
+  if (!/^[a-z][a-z0-9-]*$/i.test(parsed.name)) {
+    return {
+      valid: false,
+      error: `Invalid skill name "${parsed.name}": must be alphanumeric with hyphens`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Qualify a skill name with a namespace.
+ */
+export function qualifySkillName(namespace: string, name: string): string {
+  // If already namespaced, return as-is
+  if (name.includes("/")) {
+    return name;
+  }
+  return `${namespace}/${name}`;
+}
+
+/**
+ * Check if two skill names refer to the same skill.
+ */
+export function skillNamesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Check if a skill belongs to a namespace.
+ */
+export function skillBelongsToNamespace(skillName: string, namespace: string): boolean {
+  const parsed = parseSkillName(skillName);
+  return parsed.namespace?.toLowerCase() === namespace.toLowerCase();
+}


### PR DESCRIPTION
## Summary
Implements skill namespace isolation to prevent cross-org skill ID collisions.

## API
- `parseSkillName(name)`: Parse into namespace/name components
- `isNamespacedSkill(name)`: Check if namespaced
- `validateSkillNamespace(skill)`: Enforce namespace for publishing
- `qualifySkillName(ns, name)`: Add namespace to skill
- `skillBelongsToNamespace(skill, ns)`: Check ownership

## Testing
- 11 new tests, 206 total passing

Closes #30