### PR TITLE
feat(core): add skill access control — SKILL-010

### DIFF
--- a/packages/core/src/__tests__/skill-schema.test.ts
+++ b/packages/core/src/__tests__/skill-schema.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  type AccessContext,
+  canAccessSkill,
+  canForkSkill,
+  canInstallSkill,
   getDeprecationNotice,
+  getSkillVisibility,
   isSkillDeprecated,
   parseSkill,
   renderSkillPrompt,
@@ -270,6 +275,116 @@ prompt: Hello {{name}}
           replacement: "code-review-v2",
           since: "2026-01-01",
           removeBy: "2026-06-01",
+        },
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("access control (SKILL-010)", () => {
+    it("getSkillVisibility returns default org-private", () => {
+      expect(getSkillVisibility(validSkill)).toBe("org-private");
+    });
+
+    it("getSkillVisibility returns configured visibility", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public" },
+      };
+      expect(getSkillVisibility(skill)).toBe("public");
+    });
+
+    it("canAccessSkill allows public skills for anyone", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public" },
+      };
+      const result = canAccessSkill(skill, "acme", {});
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill allows org-private for same org", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "org-private" },
+      };
+      const result = canAccessSkill(skill, "acme", { orgId: "acme" });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill denies org-private for different org", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "org-private" },
+      };
+      const result = canAccessSkill(skill, "acme", { orgId: "other" });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("private to organization");
+    });
+
+    it("canAccessSkill allows team-private for team members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "team-private", allowedTeams: ["team-a", "team-b"] },
+      };
+      const context: AccessContext = { teamIds: ["team-b"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill denies team-private for non-members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "team-private", allowedTeams: ["team-a"] },
+      };
+      const context: AccessContext = { teamIds: ["team-c"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("restricted to specific teams");
+    });
+
+    it("canAccessSkill allows project-private for project members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "project-private", allowedProjects: ["proj-1"] },
+      };
+      const context: AccessContext = { projectIds: ["proj-1"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canInstallSkill returns true by default", () => {
+      expect(canInstallSkill(validSkill)).toBe(true);
+    });
+
+    it("canInstallSkill respects allowInstall flag", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public", allowInstall: false },
+      };
+      expect(canInstallSkill(skill)).toBe(false);
+    });
+
+    it("canForkSkill returns true by default", () => {
+      expect(canForkSkill(validSkill)).toBe(true);
+    });
+
+    it("canForkSkill respects allowFork flag", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public", allowFork: false },
+      };
+      expect(canForkSkill(skill)).toBe(false);
+    });
+
+    it("validates access control schema", () => {
+      const result = validateSkill({
+        ...validSkill,
+        access: {
+          visibility: "team-private",
+          allowedTeams: ["team-a", "team-b"],
+          allowInstall: true,
+          allowFork: false,
         },
       });
       expect(result.valid).toBe(true);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,9 @@ export {
   skillRenderers,
 } from "./skill-renderer.js";
 export type {
+  AccessContext,
   Skill,
+  SkillAccessControl,
   SkillDeprecation,
   SkillMetadata,
   SkillParameter,
@@ -31,12 +33,18 @@ export type {
   SkillToolOverride,
   SkillTrigger,
   SkillValidationResult,
+  SkillVisibility,
 } from "./skill-schema.js";
 export {
+  canAccessSkill,
+  canForkSkill,
+  canInstallSkill,
   getDeprecationNotice,
+  getSkillVisibility,
   isSkillDeprecated,
   parseSkill,
   renderSkillPrompt,
+  SkillAccessControlSchema,
   SkillDeprecationSchema,
   SkillMetadataSchema,
   SkillParameterSchema,
@@ -44,6 +52,7 @@ export {
   SkillSchema,
   SkillToolOverrideSchema,
   SkillTriggerSchema,
+  SkillVisibilitySchema,
   validateSkill,
 } from "./skill-schema.js";
 export type { SemanticVersion, VersionConstraint } from "./skill-version.js";

--- a/packages/core/src/skill-schema.ts
+++ b/packages/core/src/skill-schema.ts
@@ -140,6 +140,40 @@ export const SkillDeprecationSchema = z.object({
 export type SkillDeprecation = z.infer<typeof SkillDeprecationSchema>;
 
 /**
+ * Skill visibility levels (SKILL-010).
+ */
+export const SkillVisibilitySchema = z.enum([
+  "public", // Visible in marketplace to everyone
+  "org-private", // Visible only within the publishing organization
+  "team-private", // Visible only within a specific team
+  "project-private", // Visible only within a specific project
+]);
+
+export type SkillVisibility = z.infer<typeof SkillVisibilitySchema>;
+
+/**
+ * Access control configuration for a skill (SKILL-010).
+ */
+export const SkillAccessControlSchema = z.object({
+  /** Visibility level */
+  visibility: SkillVisibilitySchema.optional(),
+
+  /** Allowed team IDs (for team-private visibility) */
+  allowedTeams: z.array(z.string()).optional(),
+
+  /** Allowed project IDs (for project-private visibility) */
+  allowedProjects: z.array(z.string()).optional(),
+
+  /** Allow installation without explicit approval */
+  allowInstall: z.boolean().optional(),
+
+  /** Allow forking/copying */
+  allowFork: z.boolean().optional(),
+});
+
+export type SkillAccessControl = z.infer<typeof SkillAccessControlSchema>;
+
+/**
  * Tool-specific override for skill rendering.
  */
 export const SkillToolOverrideSchema = z.record(z.string(), z.unknown());
@@ -194,6 +228,9 @@ export const SkillSchema = z.object({
 
   /** Deprecation information (SKILL-012) */
   deprecation: SkillDeprecationSchema.optional(),
+
+  /** Access control (SKILL-010) */
+  access: SkillAccessControlSchema.optional(),
 });
 
 export type Skill = z.infer<typeof SkillSchema>;
@@ -310,4 +347,94 @@ export function getDeprecationNotice(skill: Skill): string | null {
   }
 
   return parts.join(" ");
+}
+
+/**
+ * Access check context for evaluating skill visibility.
+ */
+export interface AccessContext {
+  /** ID of the user requesting access */
+  userId?: string;
+  /** Organization ID of the requester */
+  orgId?: string;
+  /** Team IDs the requester belongs to */
+  teamIds?: string[];
+  /** Project IDs the requester has access to */
+  projectIds?: string[];
+}
+
+/**
+ * Get the effective visibility of a skill.
+ */
+export function getSkillVisibility(skill: Skill): SkillVisibility {
+  return skill.access?.visibility ?? "org-private";
+}
+
+/**
+ * Check if a user can access a skill based on visibility rules.
+ */
+export function canAccessSkill(
+  skill: Skill,
+  skillOrgId: string,
+  context: AccessContext,
+): { allowed: boolean; reason?: string } {
+  const visibility = getSkillVisibility(skill);
+
+  // Public skills are accessible to everyone
+  if (visibility === "public") {
+    return { allowed: true };
+  }
+
+  // Org-private requires same org
+  if (visibility === "org-private") {
+    if (context.orgId === skillOrgId) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is private to organization "${skillOrgId}"`,
+    };
+  }
+
+  // Team-private requires team membership
+  if (visibility === "team-private") {
+    const allowedTeams = skill.access?.allowedTeams ?? [];
+    const hasTeamAccess = context.teamIds?.some((t) => allowedTeams.includes(t));
+    if (hasTeamAccess) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is restricted to specific teams`,
+    };
+  }
+
+  // Project-private requires project access
+  if (visibility === "project-private") {
+    const allowedProjects = skill.access?.allowedProjects ?? [];
+    const hasProjectAccess = context.projectIds?.some((p) => allowedProjects.includes(p));
+    if (hasProjectAccess) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is restricted to specific projects`,
+    };
+  }
+
+  return { allowed: false, reason: "Unknown visibility level" };
+}
+
+/**
+ * Check if a skill allows installation.
+ */
+export function canInstallSkill(skill: Skill): boolean {
+  return skill.access?.allowInstall !== false;
+}
+
+/**
+ * Check if a skill allows forking.
+ */
+export function canForkSkill(skill: Skill): boolean {
+  return skill.access?.allowFork !== false;
 }


### PR DESCRIPTION
## Summary
Implements skill access control with visibility levels.

## Visibility Levels
- `public`: Marketplace-visible to everyone
- `org-private`: Visible only within publishing org
- `team-private`: Visible only to specified teams
- `project-private`: Visible only to specified projects

## API
- `canAccessSkill(skill, orgId, context)`: Check access with clear error reasons
- `canInstallSkill(skill)`: Check install permission
- `canForkSkill(skill)`: Check fork permission

## Testing
- 13 new tests, 208 total passing

Closes #33