### PR TITLE
feat(core): add skill access control — SKILL-010

### DIFF
--- a/packages/core/src/__tests__/skill-schema.test.ts
+++ b/packages/core/src/__tests__/skill-schema.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  type AccessContext,
+  canAccessSkill,
+  canForkSkill,
+  canInstallSkill,
   detectCircularDependency,
   getComposedSkillDependencies,
   getDeprecationNotice,
+  getSkillVisibility,
   isComposedSkill,
   isNamespacedSkill,
   isSkillDeprecated,
@@ -452,6 +457,116 @@ prompt: Hello {{name}}
           { skill: "acme/helper", params: { x: "y" }, args: { mode: "fast" }, as: "helper-result" },
           { skill: "acme/final", when: "helper-result.success" },
         ],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("access control (SKILL-010)", () => {
+    it("getSkillVisibility returns default org-private", () => {
+      expect(getSkillVisibility(validSkill)).toBe("org-private");
+    });
+
+    it("getSkillVisibility returns configured visibility", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public" },
+      };
+      expect(getSkillVisibility(skill)).toBe("public");
+    });
+
+    it("canAccessSkill allows public skills for anyone", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public" },
+      };
+      const result = canAccessSkill(skill, "acme", {});
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill allows org-private for same org", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "org-private" },
+      };
+      const result = canAccessSkill(skill, "acme", { orgId: "acme" });
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill denies org-private for different org", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "org-private" },
+      };
+      const result = canAccessSkill(skill, "acme", { orgId: "other" });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("private to organization");
+    });
+
+    it("canAccessSkill allows team-private for team members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "team-private", allowedTeams: ["team-a", "team-b"] },
+      };
+      const context: AccessContext = { teamIds: ["team-b"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canAccessSkill denies team-private for non-members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "team-private", allowedTeams: ["team-a"] },
+      };
+      const context: AccessContext = { teamIds: ["team-c"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("restricted to specific teams");
+    });
+
+    it("canAccessSkill allows project-private for project members", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "project-private", allowedProjects: ["proj-1"] },
+      };
+      const context: AccessContext = { projectIds: ["proj-1"] };
+      const result = canAccessSkill(skill, "acme", context);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("canInstallSkill returns true by default", () => {
+      expect(canInstallSkill(validSkill)).toBe(true);
+    });
+
+    it("canInstallSkill respects allowInstall flag", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public", allowInstall: false },
+      };
+      expect(canInstallSkill(skill)).toBe(false);
+    });
+
+    it("canForkSkill returns true by default", () => {
+      expect(canForkSkill(validSkill)).toBe(true);
+    });
+
+    it("canForkSkill respects allowFork flag", () => {
+      const skill: Skill = {
+        ...validSkill,
+        access: { visibility: "public", allowFork: false },
+      };
+      expect(canForkSkill(skill)).toBe(false);
+    });
+
+    it("validates access control schema", () => {
+      const result = validateSkill({
+        ...validSkill,
+        access: {
+          visibility: "team-private",
+          allowedTeams: ["team-a", "team-b"],
+          allowInstall: true,
+          allowFork: false,
+        },
       });
       expect(result.valid).toBe(true);
     });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,8 +23,10 @@ export {
   skillRenderers,
 } from "./skill-renderer.js";
 export type {
+  AccessContext,
   CircularDependencyResult,
   Skill,
+  SkillAccessControl,
   SkillDeprecation,
   SkillMetadata,
   SkillNamespace,
@@ -34,11 +36,16 @@ export type {
   SkillToolOverride,
   SkillTrigger,
   SkillValidationResult,
+  SkillVisibility,
 } from "./skill-schema.js";
 export {
+  canAccessSkill,
+  canForkSkill,
+  canInstallSkill,
   detectCircularDependency,
   getComposedSkillDependencies,
   getDeprecationNotice,
+  getSkillVisibility,
   isComposedSkill,
   isNamespacedSkill,
   isSkillDeprecated,
@@ -47,6 +54,7 @@ export {
   qualifySkillName,
   renderSkillPrompt,
   resolveStepParams,
+  SkillAccessControlSchema,
   SkillDeprecationSchema,
   SkillMetadataSchema,
   SkillParameterSchema,
@@ -55,6 +63,7 @@ export {
   SkillStepSchema,
   SkillToolOverrideSchema,
   SkillTriggerSchema,
+  SkillVisibilitySchema,
   skillBelongsToNamespace,
   skillNamesEqual,
   validateSkill,

--- a/packages/core/src/skill-schema.ts
+++ b/packages/core/src/skill-schema.ts
@@ -169,6 +169,40 @@ export const SkillStepSchema = z.object({
 export type SkillStep = z.infer<typeof SkillStepSchema>;
 
 /**
+ * Skill visibility levels (SKILL-010).
+ */
+export const SkillVisibilitySchema = z.enum([
+  "public", // Visible in marketplace to everyone
+  "org-private", // Visible only within the publishing organization
+  "team-private", // Visible only within a specific team
+  "project-private", // Visible only within a specific project
+]);
+
+export type SkillVisibility = z.infer<typeof SkillVisibilitySchema>;
+
+/**
+ * Access control configuration for a skill (SKILL-010).
+ */
+export const SkillAccessControlSchema = z.object({
+  /** Visibility level */
+  visibility: SkillVisibilitySchema.optional(),
+
+  /** Allowed team IDs (for team-private visibility) */
+  allowedTeams: z.array(z.string()).optional(),
+
+  /** Allowed project IDs (for project-private visibility) */
+  allowedProjects: z.array(z.string()).optional(),
+
+  /** Allow installation without explicit approval */
+  allowInstall: z.boolean().optional(),
+
+  /** Allow forking/copying */
+  allowFork: z.boolean().optional(),
+});
+
+export type SkillAccessControl = z.infer<typeof SkillAccessControlSchema>;
+
+/**
  * Portable skill definition.
  */
 export const SkillSchema = z.object({
@@ -219,6 +253,9 @@ export const SkillSchema = z.object({
 
   /** Composed skill steps (SKILL-008) */
   steps: z.array(SkillStepSchema).optional(),
+
+  /** Access control (SKILL-010) */
+  access: SkillAccessControlSchema.optional(),
 });
 
 export type Skill = z.infer<typeof SkillSchema>;
@@ -537,4 +574,94 @@ export function resolveStepParams(
   }
 
   return resolved;
+}
+
+/**
+ * Access check context for evaluating skill visibility.
+ */
+export interface AccessContext {
+  /** ID of the user requesting access */
+  userId?: string;
+  /** Organization ID of the requester */
+  orgId?: string;
+  /** Team IDs the requester belongs to */
+  teamIds?: string[];
+  /** Project IDs the requester has access to */
+  projectIds?: string[];
+}
+
+/**
+ * Get the effective visibility of a skill.
+ */
+export function getSkillVisibility(skill: Skill): SkillVisibility {
+  return skill.access?.visibility ?? "org-private";
+}
+
+/**
+ * Check if a user can access a skill based on visibility rules.
+ */
+export function canAccessSkill(
+  skill: Skill,
+  skillOrgId: string,
+  context: AccessContext,
+): { allowed: boolean; reason?: string } {
+  const visibility = getSkillVisibility(skill);
+
+  // Public skills are accessible to everyone
+  if (visibility === "public") {
+    return { allowed: true };
+  }
+
+  // Org-private requires same org
+  if (visibility === "org-private") {
+    if (context.orgId === skillOrgId) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is private to organization "${skillOrgId}"`,
+    };
+  }
+
+  // Team-private requires team membership
+  if (visibility === "team-private") {
+    const allowedTeams = skill.access?.allowedTeams ?? [];
+    const hasTeamAccess = context.teamIds?.some((t) => allowedTeams.includes(t));
+    if (hasTeamAccess) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is restricted to specific teams`,
+    };
+  }
+
+  // Project-private requires project access
+  if (visibility === "project-private") {
+    const allowedProjects = skill.access?.allowedProjects ?? [];
+    const hasProjectAccess = context.projectIds?.some((p) => allowedProjects.includes(p));
+    if (hasProjectAccess) {
+      return { allowed: true };
+    }
+    return {
+      allowed: false,
+      reason: `Skill "${skill.name}" is restricted to specific projects`,
+    };
+  }
+
+  return { allowed: false, reason: "Unknown visibility level" };
+}
+
+/**
+ * Check if a skill allows installation.
+ */
+export function canInstallSkill(skill: Skill): boolean {
+  return skill.access?.allowInstall !== false;
+}
+
+/**
+ * Check if a skill allows forking.
+ */
+export function canForkSkill(skill: Skill): boolean {
+  return skill.access?.allowFork !== false;
 }


### PR DESCRIPTION
## Summary
Implements skill access control with visibility levels.

## Visibility Levels
- `public`: Marketplace-visible
- `org-private`: Org-only (default)
- `team-private`: Specific teams
- `project-private`: Specific projects

## API
- `canAccessSkill(skill, orgId, context)`
- `canInstallSkill(skill)`
- `canForkSkill(skill)`
- `getSkillVisibility(skill)`

## Testing
- 13 new tests, 230 total

Closes #33