### PR TITLE
feat(core): add cost and usage tracking schema — COST-001 to COST-006

### DIFF
--- a/packages/core/src/__tests__/cost-schema.test.ts
+++ b/packages/core/src/__tests__/cost-schema.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateUsage,
+  type BudgetAlert,
+  type CostCap,
+  calculateLlmCost,
+  isCostCapExceeded,
+  type LlmUsage,
+  type ModelPricing,
+  shouldFireAlert,
+  type UsageEvent,
+} from "../cost-schema.js";
+
+describe("cost-schema", () => {
+  const samplePricing: ModelPricing = {
+    provider: "anthropic",
+    model: "claude-sonnet-4",
+    inputCostPerMillion: 3.0,
+    outputCostPerMillion: 15.0,
+    cacheReadCostPerMillion: 0.3,
+    cacheWriteCostPerMillion: 3.75,
+    effectiveDate: "2026-01-01",
+    currency: "USD",
+  };
+
+  const sampleLlmUsage: LlmUsage = {
+    provider: "anthropic",
+    model: "claude-sonnet-4",
+    inputTokens: 1000,
+    outputTokens: 500,
+    success: true,
+  };
+
+  describe("calculateLlmCost", () => {
+    it("calculates basic input/output cost", () => {
+      const cost = calculateLlmCost(sampleLlmUsage, samplePricing);
+      // 1000 input tokens = $0.003
+      // 500 output tokens = $0.0075
+      // Total = $0.0105
+      expect(cost).toBeCloseTo(0.0105, 6);
+    });
+
+    it("includes cache costs when present", () => {
+      const usageWithCache: LlmUsage = {
+        ...sampleLlmUsage,
+        cacheReadTokens: 500,
+        cacheWriteTokens: 200,
+      };
+      const cost = calculateLlmCost(usageWithCache, samplePricing);
+      // Base: $0.0105
+      // Cache read: 500 tokens = $0.00015
+      // Cache write: 200 tokens = $0.00075
+      // Total = $0.0114
+      expect(cost).toBeCloseTo(0.0114, 6);
+    });
+
+    it("returns 0 for zero tokens", () => {
+      const zeroUsage: LlmUsage = {
+        ...sampleLlmUsage,
+        inputTokens: 0,
+        outputTokens: 0,
+      };
+      const cost = calculateLlmCost(zeroUsage, samplePricing);
+      expect(cost).toBe(0);
+    });
+  });
+
+  describe("isCostCapExceeded", () => {
+    const cap: CostCap = {
+      id: "cap-1",
+      name: "Daily Cap",
+      maxAmount: 100,
+      period: "daily",
+      scope: { teamId: "team-a" },
+      action: "block",
+      enabled: true,
+    };
+
+    it("returns true when cost exceeds cap", () => {
+      expect(isCostCapExceeded(150, cap)).toBe(true);
+    });
+
+    it("returns true when cost equals cap", () => {
+      expect(isCostCapExceeded(100, cap)).toBe(true);
+    });
+
+    it("returns false when cost below cap", () => {
+      expect(isCostCapExceeded(50, cap)).toBe(false);
+    });
+
+    it("returns false when cap is disabled", () => {
+      const disabledCap = { ...cap, enabled: false };
+      expect(isCostCapExceeded(150, disabledCap)).toBe(false);
+    });
+  });
+
+  describe("shouldFireAlert", () => {
+    const alert: BudgetAlert = {
+      id: "alert-1",
+      name: "High Usage Alert",
+      threshold: 80,
+      period: "monthly",
+      recipients: ["admin@example.com"],
+      enabled: true,
+      channels: ["email"],
+    };
+
+    it("returns true when cost exceeds threshold", () => {
+      expect(shouldFireAlert(100, alert)).toBe(true);
+    });
+
+    it("returns true when cost equals threshold", () => {
+      expect(shouldFireAlert(80, alert)).toBe(true);
+    });
+
+    it("returns false when cost below threshold", () => {
+      expect(shouldFireAlert(50, alert)).toBe(false);
+    });
+
+    it("returns false when alert is disabled", () => {
+      const disabledAlert = { ...alert, enabled: false };
+      expect(shouldFireAlert(100, disabledAlert)).toBe(false);
+    });
+  });
+
+  describe("aggregateUsage", () => {
+    const pricingMap = new Map<string, ModelPricing>([
+      ["anthropic/claude-sonnet-4", samplePricing],
+    ]);
+
+    const events: UsageEvent[] = [
+      {
+        id: "evt-1",
+        type: "llm-call",
+        timestamp: "2026-01-15T10:00:00Z",
+        attribution: { userId: "user-1", teamId: "team-a" },
+        data: sampleLlmUsage,
+      },
+      {
+        id: "evt-2",
+        type: "llm-call",
+        timestamp: "2026-01-15T11:00:00Z",
+        attribution: { userId: "user-1", teamId: "team-a" },
+        data: { ...sampleLlmUsage, inputTokens: 2000, outputTokens: 1000 },
+      },
+      {
+        id: "evt-3",
+        type: "skill-invocation",
+        timestamp: "2026-01-15T12:00:00Z",
+        attribution: { userId: "user-1", skillId: "acme/code-review" },
+        data: { skillId: "acme/code-review", version: "1.0.0", success: true },
+      },
+    ];
+
+    it("aggregates costs by type", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      expect(summary.byType["llm-call"]).toBeGreaterThan(0);
+      expect(summary.byType["skill-invocation"]).toBeDefined();
+    });
+
+    it("aggregates costs by provider", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      expect(summary.byProvider?.["anthropic"]).toBeGreaterThan(0);
+    });
+
+    it("aggregates token counts", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      expect(summary.tokenCounts?.input).toBe(3000);
+      expect(summary.tokenCounts?.output).toBe(1500);
+    });
+
+    it("calculates total cost", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      // Event 1: $0.0105
+      // Event 2: $0.021 (2x input, 2x output)
+      // Total LLM: $0.0315
+      expect(summary.totalCost).toBeCloseTo(0.0315, 4);
+    });
+
+    it("sets period boundaries", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      expect(summary.periodStart).toBe("2026-01-15");
+      expect(summary.periodEnd).toBe("2026-01-16");
+    });
+  });
+});

--- a/packages/core/src/cost-schema.ts
+++ b/packages/core/src/cost-schema.ts
@@ -1,0 +1,398 @@
+import { z } from "zod";
+
+/**
+ * Usage event types (COST-001).
+ */
+export const UsageEventTypeSchema = z.enum([
+  "llm-call", // LLM API call
+  "mcp-invocation", // MCP tool invocation
+  "skill-invocation", // Skill invocation
+  "memory-operation", // Memory read/write
+]);
+
+export type UsageEventType = z.infer<typeof UsageEventTypeSchema>;
+
+/**
+ * LLM API call usage data (COST-001).
+ */
+export const LlmUsageSchema = z.object({
+  /** LLM provider (e.g., "anthropic", "openai") */
+  provider: z.string(),
+
+  /** Model ID */
+  model: z.string(),
+
+  /** Input token count */
+  inputTokens: z.number().int().nonnegative(),
+
+  /** Output token count */
+  outputTokens: z.number().int().nonnegative(),
+
+  /** Cache read tokens (if applicable) */
+  cacheReadTokens: z.number().int().nonnegative().optional(),
+
+  /** Cache write tokens (if applicable) */
+  cacheWriteTokens: z.number().int().nonnegative().optional(),
+
+  /** Request duration in milliseconds */
+  durationMs: z.number().nonnegative().optional(),
+
+  /** Whether request was successful */
+  success: z.boolean(),
+
+  /** Error code if failed */
+  errorCode: z.string().optional(),
+});
+
+export type LlmUsage = z.infer<typeof LlmUsageSchema>;
+
+/**
+ * MCP tool invocation usage data (COST-001).
+ */
+export const McpInvocationUsageSchema = z.object({
+  /** MCP server ID */
+  serverId: z.string(),
+
+  /** Tool name */
+  toolName: z.string(),
+
+  /** Invocation duration in milliseconds */
+  durationMs: z.number().nonnegative().optional(),
+
+  /** Whether invocation was successful */
+  success: z.boolean(),
+
+  /** Error message if failed */
+  error: z.string().optional(),
+});
+
+export type McpInvocationUsage = z.infer<typeof McpInvocationUsageSchema>;
+
+/**
+ * Skill invocation usage data (COST-001).
+ */
+export const SkillInvocationUsageSchema = z.object({
+  /** Skill ID (namespace/name) */
+  skillId: z.string(),
+
+  /** Skill version */
+  version: z.string().optional(),
+
+  /** Invocation duration in milliseconds */
+  durationMs: z.number().nonnegative().optional(),
+
+  /** Whether invocation was successful */
+  success: z.boolean(),
+
+  /** Error message if failed */
+  error: z.string().optional(),
+});
+
+export type SkillInvocationUsage = z.infer<typeof SkillInvocationUsageSchema>;
+
+/**
+ * Memory operation usage data (COST-001).
+ */
+export const MemoryOperationUsageSchema = z.object({
+  /** Operation type */
+  operation: z.enum(["read", "write", "search", "delete"]),
+
+  /** Memory scope (e.g., "session", "project", "user") */
+  scope: z.string(),
+
+  /** Number of items affected */
+  itemCount: z.number().int().nonnegative().optional(),
+
+  /** Size in bytes (if applicable) */
+  sizeBytes: z.number().int().nonnegative().optional(),
+
+  /** Operation duration in milliseconds */
+  durationMs: z.number().nonnegative().optional(),
+
+  /** Whether operation was successful */
+  success: z.boolean(),
+});
+
+export type MemoryOperationUsage = z.infer<typeof MemoryOperationUsageSchema>;
+
+/**
+ * Attribution dimensions (COST-002).
+ */
+export const UsageAttributionSchema = z.object({
+  /** Developer/user ID */
+  userId: z.string().optional(),
+
+  /** Team ID */
+  teamId: z.string().optional(),
+
+  /** Project ID */
+  projectId: z.string().optional(),
+
+  /** Organization ID */
+  orgId: z.string().optional(),
+
+  /** Skill ID (for skill attribution) */
+  skillId: z.string().optional(),
+
+  /** Session ID */
+  sessionId: z.string().optional(),
+
+  /** Business unit / cost center (COST-011) */
+  costCenter: z.string().optional(),
+});
+
+export type UsageAttribution = z.infer<typeof UsageAttributionSchema>;
+
+/**
+ * Usage event record (COST-001).
+ */
+export const UsageEventSchema = z.object({
+  /** Unique event ID */
+  id: z.string(),
+
+  /** Event type */
+  type: UsageEventTypeSchema,
+
+  /** ISO 8601 timestamp */
+  timestamp: z.string(),
+
+  /** Attribution dimensions */
+  attribution: UsageAttributionSchema,
+
+  /** Type-specific usage data */
+  data: z.union([
+    LlmUsageSchema,
+    McpInvocationUsageSchema,
+    SkillInvocationUsageSchema,
+    MemoryOperationUsageSchema,
+  ]),
+});
+
+export type UsageEvent = z.infer<typeof UsageEventSchema>;
+
+/**
+ * Model pricing configuration (COST-003).
+ */
+export const ModelPricingSchema = z.object({
+  /** Provider ID */
+  provider: z.string(),
+
+  /** Model ID */
+  model: z.string(),
+
+  /** Cost per 1M input tokens (USD) */
+  inputCostPerMillion: z.number().nonnegative(),
+
+  /** Cost per 1M output tokens (USD) */
+  outputCostPerMillion: z.number().nonnegative(),
+
+  /** Cost per 1M cache read tokens (USD) */
+  cacheReadCostPerMillion: z.number().nonnegative().optional(),
+
+  /** Cost per 1M cache write tokens (USD) */
+  cacheWriteCostPerMillion: z.number().nonnegative().optional(),
+
+  /** Effective date */
+  effectiveDate: z.string(),
+
+  /** Currency code */
+  currency: z.string().default("USD"),
+});
+
+export type ModelPricing = z.infer<typeof ModelPricingSchema>;
+
+/**
+ * Budget alert configuration (COST-004).
+ */
+export const BudgetAlertSchema = z.object({
+  /** Alert ID */
+  id: z.string(),
+
+  /** Alert name */
+  name: z.string(),
+
+  /** Threshold amount (USD) */
+  threshold: z.number().positive(),
+
+  /** Time period */
+  period: z.enum(["daily", "weekly", "monthly", "quarterly", "yearly"]),
+
+  /** Attribution filter */
+  filter: UsageAttributionSchema.optional(),
+
+  /** Alert recipients */
+  recipients: z.array(z.string()),
+
+  /** Whether alert is enabled */
+  enabled: z.boolean().default(true),
+
+  /** Notification channels */
+  channels: z.array(z.enum(["email", "slack", "webhook"])).default(["email"]),
+});
+
+export type BudgetAlert = z.infer<typeof BudgetAlertSchema>;
+
+/**
+ * Cost cap policy (COST-005).
+ */
+export const CostCapSchema = z.object({
+  /** Cap ID */
+  id: z.string(),
+
+  /** Cap name */
+  name: z.string(),
+
+  /** Maximum amount (USD) */
+  maxAmount: z.number().positive(),
+
+  /** Time period */
+  period: z.enum(["daily", "weekly", "monthly"]),
+
+  /** Attribution scope */
+  scope: UsageAttributionSchema,
+
+  /** Action when cap is reached */
+  action: z.enum(["warn", "throttle", "block"]),
+
+  /** Whether cap is enabled */
+  enabled: z.boolean().default(true),
+});
+
+export type CostCap = z.infer<typeof CostCapSchema>;
+
+/**
+ * Cost summary for a time period (COST-006).
+ */
+export const CostSummarySchema = z.object({
+  /** Start of period */
+  periodStart: z.string(),
+
+  /** End of period */
+  periodEnd: z.string(),
+
+  /** Total cost (USD) */
+  totalCost: z.number().nonnegative(),
+
+  /** Cost breakdown by type */
+  byType: z.record(UsageEventTypeSchema, z.number().nonnegative()),
+
+  /** Cost breakdown by provider */
+  byProvider: z.record(z.string(), z.number().nonnegative()).optional(),
+
+  /** Cost breakdown by model */
+  byModel: z.record(z.string(), z.number().nonnegative()).optional(),
+
+  /** Cost breakdown by skill */
+  bySkill: z.record(z.string(), z.number().nonnegative()).optional(),
+
+  /** Token counts */
+  tokenCounts: z
+    .object({
+      input: z.number().int().nonnegative(),
+      output: z.number().int().nonnegative(),
+      cacheRead: z.number().int().nonnegative().optional(),
+      cacheWrite: z.number().int().nonnegative().optional(),
+    })
+    .optional(),
+
+  /** Currency code */
+  currency: z.string().default("USD"),
+});
+
+export type CostSummary = z.infer<typeof CostSummarySchema>;
+
+/**
+ * Calculate cost for an LLM usage event.
+ */
+export function calculateLlmCost(usage: LlmUsage, pricing: ModelPricing): number {
+  let cost = 0;
+
+  // Input tokens
+  cost += (usage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
+
+  // Output tokens
+  cost += (usage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
+
+  // Cache read tokens
+  if (usage.cacheReadTokens && pricing.cacheReadCostPerMillion) {
+    cost += (usage.cacheReadTokens / 1_000_000) * pricing.cacheReadCostPerMillion;
+  }
+
+  // Cache write tokens
+  if (usage.cacheWriteTokens && pricing.cacheWriteCostPerMillion) {
+    cost += (usage.cacheWriteTokens / 1_000_000) * pricing.cacheWriteCostPerMillion;
+  }
+
+  return cost;
+}
+
+/**
+ * Check if a cost cap is exceeded.
+ */
+export function isCostCapExceeded(currentCost: number, cap: CostCap): boolean {
+  return cap.enabled && currentCost >= cap.maxAmount;
+}
+
+/**
+ * Check if a budget alert should fire.
+ */
+export function shouldFireAlert(currentCost: number, alert: BudgetAlert): boolean {
+  return alert.enabled && currentCost >= alert.threshold;
+}
+
+/**
+ * Aggregate usage events into a cost summary.
+ */
+export function aggregateUsage(
+  events: UsageEvent[],
+  pricing: Map<string, ModelPricing>,
+  periodStart: string,
+  periodEnd: string,
+): CostSummary {
+  const byType: Record<string, number> = {};
+  const byProvider: Record<string, number> = {};
+  const byModel: Record<string, number> = {};
+  const bySkill: Record<string, number> = {};
+  let totalCost = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  for (const event of events) {
+    let eventCost = 0;
+
+    if (event.type === "llm-call") {
+      const data = event.data as LlmUsage;
+      const key = `${data.provider}/${data.model}`;
+      const modelPricing = pricing.get(key);
+
+      if (modelPricing) {
+        eventCost = calculateLlmCost(data, modelPricing);
+        byProvider[data.provider] = (byProvider[data.provider] ?? 0) + eventCost;
+        byModel[key] = (byModel[key] ?? 0) + eventCost;
+      }
+
+      inputTokens += data.inputTokens;
+      outputTokens += data.outputTokens;
+    }
+
+    if (event.type === "skill-invocation") {
+      const data = event.data as { skillId: string };
+      bySkill[data.skillId] = (bySkill[data.skillId] ?? 0) + eventCost;
+    }
+
+    byType[event.type] = (byType[event.type] ?? 0) + eventCost;
+    totalCost += eventCost;
+  }
+
+  return {
+    periodStart,
+    periodEnd,
+    totalCost,
+    byType: byType as Record<UsageEventType, number>,
+    byProvider,
+    byModel,
+    bySkill,
+    tokenCounts: { input: inputTokens, output: outputTokens },
+    currency: "USD",
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,34 @@
 export type { ToolAdapter, ToolCategory } from "./adapter.js";
+export type {
+  BudgetAlert,
+  CostCap,
+  CostSummary,
+  LlmUsage,
+  McpInvocationUsage,
+  MemoryOperationUsage,
+  ModelPricing,
+  SkillInvocationUsage,
+  UsageAttribution,
+  UsageEvent,
+  UsageEventType,
+} from "./cost-schema.js";
+export {
+  aggregateUsage,
+  BudgetAlertSchema,
+  CostCapSchema,
+  CostSummarySchema,
+  calculateLlmCost,
+  isCostCapExceeded,
+  LlmUsageSchema,
+  McpInvocationUsageSchema,
+  MemoryOperationUsageSchema,
+  ModelPricingSchema,
+  SkillInvocationUsageSchema,
+  shouldFireAlert,
+  UsageAttributionSchema,
+  UsageEventSchema,
+  UsageEventTypeSchema,
+} from "./cost-schema.js";
 export type { HierarchyLoadResult, HierarchyOptions } from "./hierarchy.js";
 export { findRootInstruction, loadHierarchy } from "./hierarchy.js";
 export type { ImportFormat, ImportResult } from "./import.js";


### PR DESCRIPTION
## Summary
Adds comprehensive cost and usage tracking schema covering 6 COST requirements.

## Usage Schemas (COST-001)
- `UsageEventSchema`: Core event record
- `LlmUsageSchema`: LLM API metrics (tokens, duration, success)
- `McpInvocationUsageSchema`: MCP tool metrics
- `SkillInvocationUsageSchema`: Skill metrics
- `MemoryOperationUsageSchema`: Memory operation metrics

## Attribution (COST-002)
- `UsageAttributionSchema`: User, team, project, org, skill, cost center

## Pricing & Alerts
- `ModelPricingSchema`: Dynamic pricing config (COST-003)
- `BudgetAlertSchema`: Configurable alerts (COST-004)
- `CostCapSchema`: Policy-enforced limits (COST-005)
- `CostSummarySchema`: Dashboard aggregations (COST-006)

## Functions
- `calculateLlmCost()`: Cost calculation with cache support
- `aggregateUsage()`: Summarize events with attribution
- `isCostCapExceeded()`, `shouldFireAlert()`: Policy checks

## Testing
- 16 new tests, 256 total passing

Addresses #96, #97, #98, #99, #100, #101