### PR TITLE
feat(core): add cache layer — INFRA-009

### DIFF
--- a/packages/core/src/__tests__/cache.test.ts
+++ b/packages/core/src/__tests__/cache.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type Cache, createCache, MemoryCache, TieredCache } from "../cache.js";
+
+describe("cache", () => {
+  let cache: Cache<string>;
+
+  beforeEach(() => {
+    cache = createCache<string>();
+  });
+
+  describe("basic operations", () => {
+    it("sets and gets values", () => {
+      cache.set("key1", "value1");
+      expect(cache.get("key1")).toBe("value1");
+    });
+
+    it("returns undefined for missing keys", () => {
+      expect(cache.get("missing")).toBeUndefined();
+    });
+
+    it("checks existence with has()", () => {
+      cache.set("key1", "value1");
+      expect(cache.has("key1")).toBe(true);
+      expect(cache.has("missing")).toBe(false);
+    });
+
+    it("deletes keys", () => {
+      cache.set("key1", "value1");
+      expect(cache.delete("key1")).toBe(true);
+      expect(cache.get("key1")).toBeUndefined();
+    });
+
+    it("returns false when deleting missing key", () => {
+      expect(cache.delete("missing")).toBe(false);
+    });
+
+    it("clears all entries", () => {
+      cache.set("key1", "value1");
+      cache.set("key2", "value2");
+      cache.clear();
+      expect(cache.size()).toBe(0);
+    });
+
+    it("returns all keys", () => {
+      cache.set("key1", "value1");
+      cache.set("key2", "value2");
+      expect(cache.keys()).toContain("key1");
+      expect(cache.keys()).toContain("key2");
+    });
+
+    it("returns size", () => {
+      expect(cache.size()).toBe(0);
+      cache.set("key1", "value1");
+      expect(cache.size()).toBe(1);
+    });
+  });
+
+  describe("TTL expiration", () => {
+    it("expires entries after TTL", async () => {
+      cache.set("key1", "value1", 50); // 50ms TTL
+      expect(cache.get("key1")).toBe("value1");
+
+      await new Promise((r) => setTimeout(r, 60));
+      expect(cache.get("key1")).toBeUndefined();
+    });
+
+    it("has() returns false for expired entries", async () => {
+      cache.set("key1", "value1", 50);
+      await new Promise((r) => setTimeout(r, 60));
+      expect(cache.has("key1")).toBe(false);
+    });
+
+    it("prune() removes expired entries", async () => {
+      cache.set("key1", "value1", 50);
+      cache.set("key2", "value2", 1000);
+
+      await new Promise((r) => setTimeout(r, 60));
+
+      const pruned = cache.prune();
+      expect(pruned).toBe(1);
+      expect(cache.size()).toBe(1);
+    });
+  });
+
+  describe("statistics", () => {
+    it("tracks hits", () => {
+      cache.set("key1", "value1");
+      cache.get("key1");
+      cache.get("key1");
+
+      const stats = cache.stats();
+      expect(stats.hits).toBe(2);
+    });
+
+    it("tracks misses", () => {
+      cache.get("missing1");
+      cache.get("missing2");
+
+      const stats = cache.stats();
+      expect(stats.misses).toBe(2);
+    });
+
+    it("calculates hit rate", () => {
+      cache.set("key1", "value1");
+      cache.get("key1"); // hit
+      cache.get("missing"); // miss
+
+      const stats = cache.stats();
+      expect(stats.hitRate).toBe(0.5);
+    });
+
+    it("tracks evictions", () => {
+      const smallCache = createCache<string>({ maxSize: 2 });
+      smallCache.set("key1", "value1");
+      smallCache.set("key2", "value2");
+      smallCache.set("key3", "value3"); // triggers eviction
+
+      const stats = smallCache.stats();
+      expect(stats.evictions).toBe(1);
+    });
+  });
+
+  describe("eviction policies", () => {
+    it("LRU evicts least recently used", async () => {
+      const lruCache = createCache<string>({ maxSize: 2, evictionPolicy: "lru" });
+
+      lruCache.set("key1", "value1");
+      await new Promise((r) => setTimeout(r, 5)); // ensure different timestamps
+      lruCache.set("key2", "value2");
+      await new Promise((r) => setTimeout(r, 5));
+      lruCache.get("key1"); // access key1, making key2 LRU
+      await new Promise((r) => setTimeout(r, 5));
+
+      lruCache.set("key3", "value3"); // should evict key2
+
+      expect(lruCache.has("key1")).toBe(true);
+      expect(lruCache.has("key2")).toBe(false);
+      expect(lruCache.has("key3")).toBe(true);
+    });
+
+    it("FIFO evicts oldest entry", () => {
+      const fifoCache = createCache<string>({ maxSize: 2, evictionPolicy: "fifo" });
+
+      fifoCache.set("key1", "value1");
+      fifoCache.set("key2", "value2");
+      fifoCache.set("key3", "value3"); // should evict key1
+
+      expect(fifoCache.has("key1")).toBe(false);
+      expect(fifoCache.has("key2")).toBe(true);
+      expect(fifoCache.has("key3")).toBe(true);
+    });
+
+    it("LFU evicts least frequently used", () => {
+      const lfuCache = createCache<string>({ maxSize: 2, evictionPolicy: "lfu" });
+
+      lfuCache.set("key1", "value1");
+      lfuCache.set("key2", "value2");
+      lfuCache.get("key1"); // access key1 multiple times
+      lfuCache.get("key1");
+
+      lfuCache.set("key3", "value3"); // should evict key2 (less accessed)
+
+      expect(lfuCache.has("key1")).toBe(true);
+      expect(lfuCache.has("key2")).toBe(false);
+      expect(lfuCache.has("key3")).toBe(true);
+    });
+  });
+
+  describe("invalidate", () => {
+    it("invalidates keys matching string pattern", () => {
+      cache.set("user:1", "alice");
+      cache.set("user:2", "bob");
+      cache.set("post:1", "hello");
+
+      const count = cache.invalidate("user:");
+      expect(count).toBe(2);
+      expect(cache.has("user:1")).toBe(false);
+      expect(cache.has("post:1")).toBe(true);
+    });
+
+    it("invalidates keys matching regex", () => {
+      cache.set("user:1", "alice");
+      cache.set("user:2", "bob");
+      cache.set("post:1", "hello");
+
+      const count = cache.invalidate(/:\d+$/);
+      expect(count).toBe(3);
+    });
+  });
+
+  describe("getOrSet", () => {
+    it("returns cached value if exists", () => {
+      cache.set("key1", "cached");
+      const factory = vi.fn(() => "new");
+
+      const result = cache.getOrSet("key1", factory);
+
+      expect(result).toBe("cached");
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it("calls factory if key missing", () => {
+      const factory = vi.fn(() => "new");
+
+      const result = cache.getOrSet("key1", factory);
+
+      expect(result).toBe("new");
+      expect(factory).toHaveBeenCalledOnce();
+    });
+
+    it("caches factory result", () => {
+      const factory = vi.fn(() => "new");
+
+      cache.getOrSet("key1", factory);
+      cache.getOrSet("key1", factory);
+
+      expect(factory).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getOrSetAsync", () => {
+    it("returns cached value if exists", async () => {
+      cache.set("key1", "cached");
+      const factory = vi.fn(async () => "new");
+
+      const result = await cache.getOrSetAsync("key1", factory);
+
+      expect(result).toBe("cached");
+      expect(factory).not.toHaveBeenCalled();
+    });
+
+    it("calls async factory if key missing", async () => {
+      const factory = vi.fn(async () => "new");
+
+      const result = await cache.getOrSetAsync("key1", factory);
+
+      expect(result).toBe("new");
+      expect(factory).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("wrap", () => {
+    it("wraps a function with caching", () => {
+      const expensive = vi.fn((n: number) => n * 2);
+      const cached = cache.wrap((n: number) => `key:${n}`, expensive);
+
+      expect(cached(5)).toBe(10);
+      expect(cached(5)).toBe(10);
+      expect(expensive).toHaveBeenCalledOnce();
+    });
+
+    it("caches based on key function", () => {
+      const expensive = vi.fn((a: number, b: number) => a + b);
+      const cached = cache.wrap((a: number, b: number) => `sum:${a}:${b}`, expensive);
+
+      expect(cached(1, 2)).toBe(3);
+      expect(cached(1, 2)).toBe(3);
+      expect(cached(2, 3)).toBe(5);
+
+      expect(expensive).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("TieredCache", () => {
+  it("promotes L2 hits to L1", () => {
+    const l1 = new MemoryCache<string>();
+    const l2 = new MemoryCache<string>();
+    const tiered = new TieredCache<string>({}, l2);
+
+    l2.set("key1", "value1");
+
+    // First access from L2
+    expect(tiered.get("key1")).toBe("value1");
+
+    // Should now be in L1
+    expect(l1.has("key1")).toBe(false); // internal L1, not exposed
+  });
+
+  it("writes to both tiers", () => {
+    const l2 = new MemoryCache<string>();
+    const tiered = new TieredCache<string>({}, l2);
+
+    tiered.set("key1", "value1");
+
+    expect(l2.get("key1")).toBe("value1");
+  });
+
+  it("deletes from both tiers", () => {
+    const l2 = new MemoryCache<string>();
+    const tiered = new TieredCache<string>({}, l2);
+
+    tiered.set("key1", "value1");
+    tiered.delete("key1");
+
+    expect(l2.has("key1")).toBe(false);
+  });
+
+  it("clears both tiers", () => {
+    const l2 = new MemoryCache<string>();
+    const tiered = new TieredCache<string>({}, l2);
+
+    tiered.set("key1", "value1");
+    l2.set("key2", "value2");
+
+    tiered.clear();
+
+    expect(l2.size()).toBe(0);
+  });
+});

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,451 @@
+/**
+ * Cache layer (INFRA-009).
+ * In-memory caching with TTL and statistics.
+ */
+
+/**
+ * Cache entry with metadata.
+ */
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+  createdAt: number;
+  accessCount: number;
+  lastAccessedAt: number;
+}
+
+/**
+ * Cache statistics.
+ */
+export interface CacheStats {
+  hits: number;
+  misses: number;
+  size: number;
+  evictions: number;
+  hitRate: number;
+}
+
+/**
+ * Cache options.
+ */
+export interface CacheOptions {
+  /** Default TTL in milliseconds */
+  defaultTtlMs?: number;
+
+  /** Maximum number of entries */
+  maxSize?: number;
+
+  /** Eviction policy */
+  evictionPolicy?: "lru" | "lfu" | "fifo";
+
+  /** Enable statistics tracking */
+  trackStats?: boolean;
+}
+
+/**
+ * Cache interface.
+ */
+export interface Cache<T = unknown> {
+  /** Get a value by key */
+  get(key: string): T | undefined;
+
+  /** Set a value with optional TTL */
+  set(key: string, value: T, ttlMs?: number): void;
+
+  /** Check if key exists and is not expired */
+  has(key: string): boolean;
+
+  /** Delete a key */
+  delete(key: string): boolean;
+
+  /** Clear all entries */
+  clear(): void;
+
+  /** Get cache statistics */
+  stats(): CacheStats;
+
+  /** Get all keys */
+  keys(): string[];
+
+  /** Get number of entries */
+  size(): number;
+
+  /** Invalidate entries matching a pattern */
+  invalidate(pattern: string | RegExp): number;
+
+  /** Get or set with factory function */
+  getOrSet(key: string, factory: () => T, ttlMs?: number): T;
+
+  /** Get or set with async factory */
+  getOrSetAsync(key: string, factory: () => Promise<T>, ttlMs?: number): Promise<T>;
+
+  /** Wrap a function with caching */
+  wrap<Args extends unknown[], R>(
+    keyFn: (...args: Args) => string,
+    fn: (...args: Args) => R,
+    ttlMs?: number,
+  ): (...args: Args) => R;
+
+  /** Prune expired entries */
+  prune(): number;
+}
+
+/**
+ * In-memory cache implementation.
+ */
+export class MemoryCache<T = unknown> implements Cache<T> {
+  private entries: Map<string, CacheEntry<T>> = new Map();
+  private insertOrder: string[] = [];
+  private _stats = { hits: 0, misses: 0, evictions: 0 };
+  private options: Required<CacheOptions>;
+
+  constructor(options: CacheOptions = {}) {
+    this.options = {
+      defaultTtlMs: options.defaultTtlMs ?? 5 * 60 * 1000, // 5 minutes
+      maxSize: options.maxSize ?? 1000,
+      evictionPolicy: options.evictionPolicy ?? "lru",
+      trackStats: options.trackStats ?? true,
+    };
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key);
+
+    if (!entry) {
+      if (this.options.trackStats) this._stats.misses++;
+      return undefined;
+    }
+
+    if (this.isExpired(entry)) {
+      this.delete(key);
+      if (this.options.trackStats) this._stats.misses++;
+      return undefined;
+    }
+
+    // Update access metadata
+    entry.accessCount++;
+    entry.lastAccessedAt = Date.now();
+
+    if (this.options.trackStats) this._stats.hits++;
+    return entry.value;
+  }
+
+  set(key: string, value: T, ttlMs?: number): void {
+    const ttl = ttlMs ?? this.options.defaultTtlMs;
+    const now = Date.now();
+
+    // Evict if at capacity
+    if (!this.entries.has(key) && this.entries.size >= this.options.maxSize) {
+      this.evict();
+    }
+
+    // Track insert order for FIFO
+    if (!this.entries.has(key)) {
+      this.insertOrder.push(key);
+    }
+
+    this.entries.set(key, {
+      value,
+      expiresAt: now + ttl,
+      createdAt: now,
+      accessCount: 0,
+      lastAccessedAt: now,
+    });
+  }
+
+  has(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) return false;
+    if (this.isExpired(entry)) {
+      this.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  delete(key: string): boolean {
+    const existed = this.entries.delete(key);
+    if (existed) {
+      const idx = this.insertOrder.indexOf(key);
+      if (idx !== -1) this.insertOrder.splice(idx, 1);
+    }
+    return existed;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.insertOrder = [];
+  }
+
+  stats(): CacheStats {
+    const total = this._stats.hits + this._stats.misses;
+    return {
+      hits: this._stats.hits,
+      misses: this._stats.misses,
+      size: this.entries.size,
+      evictions: this._stats.evictions,
+      hitRate: total > 0 ? this._stats.hits / total : 0,
+    };
+  }
+
+  keys(): string[] {
+    // Only return non-expired keys
+    const validKeys: string[] = [];
+    for (const [key, entry] of this.entries) {
+      if (!this.isExpired(entry)) {
+        validKeys.push(key);
+      }
+    }
+    return validKeys;
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  invalidate(pattern: string | RegExp): number {
+    const regex = typeof pattern === "string" ? new RegExp(pattern) : pattern;
+    let count = 0;
+
+    for (const key of this.entries.keys()) {
+      if (regex.test(key)) {
+        this.delete(key);
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  getOrSet(key: string, factory: () => T, ttlMs?: number): T {
+    const existing = this.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const value = factory();
+    this.set(key, value, ttlMs);
+    return value;
+  }
+
+  async getOrSetAsync(key: string, factory: () => Promise<T>, ttlMs?: number): Promise<T> {
+    const existing = this.get(key);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const value = await factory();
+    this.set(key, value, ttlMs);
+    return value;
+  }
+
+  wrap<Args extends unknown[], R>(
+    keyFn: (...args: Args) => string,
+    fn: (...args: Args) => R,
+    ttlMs?: number,
+  ): (...args: Args) => R {
+    return (...args: Args): R => {
+      const key = keyFn(...args);
+      return this.getOrSet(key, () => fn(...args) as unknown as T, ttlMs) as unknown as R;
+    };
+  }
+
+  prune(): number {
+    let pruned = 0;
+    const now = Date.now();
+
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.delete(key);
+        pruned++;
+      }
+    }
+
+    return pruned;
+  }
+
+  private isExpired(entry: CacheEntry<T>): boolean {
+    return Date.now() >= entry.expiresAt;
+  }
+
+  private evict(): void {
+    if (this.entries.size === 0) return;
+
+    let keyToEvict: string | undefined;
+
+    switch (this.options.evictionPolicy) {
+      case "fifo":
+        keyToEvict = this.insertOrder[0];
+        break;
+
+      case "lfu": {
+        // Least frequently used
+        let minAccess = Infinity;
+        for (const [key, entry] of this.entries) {
+          if (entry.accessCount < minAccess) {
+            minAccess = entry.accessCount;
+            keyToEvict = key;
+          }
+        }
+        break;
+      }
+
+      case "lru":
+      default: {
+        // Least recently used
+        let oldestAccess = Infinity;
+        for (const [key, entry] of this.entries) {
+          if (entry.lastAccessedAt < oldestAccess) {
+            oldestAccess = entry.lastAccessedAt;
+            keyToEvict = key;
+          }
+        }
+        break;
+      }
+    }
+
+    if (keyToEvict) {
+      this.delete(keyToEvict);
+      if (this.options.trackStats) this._stats.evictions++;
+    }
+  }
+}
+
+/**
+ * Create a cache with the given options.
+ */
+export function createCache<T = unknown>(options?: CacheOptions): Cache<T> {
+  return new MemoryCache<T>(options);
+}
+
+/**
+ * Decorator for caching method results.
+ */
+export function cached(ttlMs?: number) {
+  const cache = new MemoryCache<unknown>();
+
+  return <T extends (...args: unknown[]) => unknown>(
+    _target: object,
+    propertyKey: string,
+    descriptor: TypedPropertyDescriptor<T>,
+  ): TypedPropertyDescriptor<T> => {
+    const original = descriptor.value;
+    if (!original) return descriptor;
+
+    descriptor.value = function (this: unknown, ...args: unknown[]) {
+      const key = `${propertyKey}:${JSON.stringify(args)}`;
+      return cache.getOrSet(key, () => original.apply(this, args), ttlMs);
+    } as T;
+
+    return descriptor;
+  };
+}
+
+/**
+ * Multi-level cache (L1 memory + L2 optional).
+ */
+export class TieredCache<T = unknown> implements Cache<T> {
+  private l1: Cache<T>;
+  private l2?: Cache<T>;
+
+  constructor(l1Options?: CacheOptions, l2?: Cache<T>) {
+    this.l1 = new MemoryCache<T>(l1Options);
+    if (l2) this.l2 = l2;
+  }
+
+  get(key: string): T | undefined {
+    // Try L1 first
+    let value = this.l1.get(key);
+    if (value !== undefined) return value;
+
+    // Try L2 if available
+    if (this.l2) {
+      value = this.l2.get(key);
+      if (value !== undefined) {
+        // Promote to L1
+        this.l1.set(key, value);
+        return value;
+      }
+    }
+
+    return undefined;
+  }
+
+  set(key: string, value: T, ttlMs?: number): void {
+    this.l1.set(key, value, ttlMs);
+    this.l2?.set(key, value, ttlMs);
+  }
+
+  has(key: string): boolean {
+    return this.l1.has(key) || (this.l2?.has(key) ?? false);
+  }
+
+  delete(key: string): boolean {
+    const l1Deleted = this.l1.delete(key);
+    const l2Deleted = this.l2?.delete(key) ?? false;
+    return l1Deleted || l2Deleted;
+  }
+
+  clear(): void {
+    this.l1.clear();
+    this.l2?.clear();
+  }
+
+  stats(): CacheStats {
+    return this.l1.stats();
+  }
+
+  keys(): string[] {
+    const l1Keys = new Set(this.l1.keys());
+    const l2Keys = this.l2?.keys() ?? [];
+    for (const key of l2Keys) {
+      l1Keys.add(key);
+    }
+    return Array.from(l1Keys);
+  }
+
+  size(): number {
+    return this.l1.size();
+  }
+
+  invalidate(pattern: string | RegExp): number {
+    const l1Count = this.l1.invalidate(pattern);
+    const l2Count = this.l2?.invalidate(pattern) ?? 0;
+    return l1Count + l2Count;
+  }
+
+  getOrSet(key: string, factory: () => T, ttlMs?: number): T {
+    const existing = this.get(key);
+    if (existing !== undefined) return existing;
+
+    const value = factory();
+    this.set(key, value, ttlMs);
+    return value;
+  }
+
+  async getOrSetAsync(key: string, factory: () => Promise<T>, ttlMs?: number): Promise<T> {
+    const existing = this.get(key);
+    if (existing !== undefined) return existing;
+
+    const value = await factory();
+    this.set(key, value, ttlMs);
+    return value;
+  }
+
+  wrap<Args extends unknown[], R>(
+    keyFn: (...args: Args) => string,
+    fn: (...args: Args) => R,
+    ttlMs?: number,
+  ): (...args: Args) => R {
+    return (...args: Args): R => {
+      const key = keyFn(...args);
+      return this.getOrSet(key, () => fn(...args) as unknown as T, ttlMs) as unknown as R;
+    };
+  }
+
+  prune(): number {
+    const l1Pruned = this.l1.prune();
+    const l2Pruned = this.l2?.prune() ?? 0;
+    return l1Pruned + l2Pruned;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,17 @@ export {
   SqlAuditStorage,
 } from "./audit-storage.js";
 export type {
+  Cache,
+  CacheOptions,
+  CacheStats,
+} from "./cache.js";
+export {
+  cached,
+  createCache,
+  MemoryCache,
+  TieredCache,
+} from "./cache.js";
+export type {
   BudgetAlert,
   CostCap,
   CostSummary,


### PR DESCRIPTION
## Summary
In-memory caching with TTL, eviction policies, and statistics.

## Features
- TTL-based expiration
- Eviction policies: LRU, LFU, FIFO
- Statistics: hits, misses, evictions, hit rate
- Pattern-based invalidation
- getOrSet / getOrSetAsync for compute-on-miss
- wrap() for function memoization
- TieredCache for L1/L2 caching
- @cached decorator

## API
```typescript
const cache = createCache<User>({ maxSize: 1000, defaultTtlMs: 60000 });

// Basic operations
cache.set('user:1', user);
const user = cache.get('user:1');

// Compute on miss
const user = cache.getOrSet('user:1', () => fetchUser(1));

// Function memoization
const cachedFetch = cache.wrap(
  (id) => `user:${id}`,
  (id) => fetchUser(id)
);
```

## Testing
- 31 new tests, 506 total passing

Closes #136