### PR TITLE
feat(adapters): add Codex, Copilot, and OpenCode adapters

### DIFF
--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@laup/codex",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "*",
+    "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "@laup/core": "workspace:*"
+  }
+}

--- a/packages/adapters/codex/src/__tests__/golden/canonical-input.md
+++ b/packages/adapters/codex/src/__tests__/golden/canonical-input.md
@@ -1,0 +1,14 @@
+---
+version: "1.0"
+scope: project
+---
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/codex/src/__tests__/golden/expected-output.md
+++ b/packages/adapters/codex/src/__tests__/golden/expected-output.md
@@ -1,0 +1,11 @@
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/codex/src/__tests__/index.test.ts
+++ b/packages/adapters/codex/src/__tests__/index.test.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCanonicalString } from "@laup/core";
+import { describe, expect, it } from "vitest";
+import { CodexAdapter, codexAdapter } from "../index.js";
+
+const fixture = (name: string) => readFileSync(join(import.meta.dirname, "golden", name), "utf-8");
+
+describe("CodexAdapter", () => {
+  it("has correct toolId and displayName", () => {
+    expect(codexAdapter.toolId).toBe("codex");
+    expect(codexAdapter.displayName).toBe("Codex CLI");
+  });
+
+  it("has category 'cli'", () => {
+    expect(codexAdapter.category).toBe("cli");
+  });
+
+  describe("render()", () => {
+    it("golden-file: renders canonical input to expected output", () => {
+      const input = fixture("canonical-input.md");
+      const expected = fixture("expected-output.md");
+      const doc = parseCanonicalString(input);
+      expect(codexAdapter.render(doc)).toBe(expected.trimEnd());
+    });
+
+    it("prepends the generated-file comment header", () => {
+      const doc = parseCanonicalString("# Body\n\nSome text.");
+      expect(codexAdapter.render(doc)).toMatch(/^<!-- laup:generated/);
+    });
+
+    it("preserves the full body content", () => {
+      const body = "# My Rules\n\nDo the thing.";
+      const doc = parseCanonicalString(body);
+      expect(codexAdapter.render(doc)).toContain(body);
+    });
+
+    it("does not include trailing whitespace", () => {
+      const doc = parseCanonicalString("# Body\n\nText.\n\n\n");
+      expect(codexAdapter.render(doc)).not.toMatch(/\s+$/);
+    });
+  });
+
+  describe("write()", () => {
+    it("writes to AGENTS.md", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = codexAdapter.render(doc);
+
+      const paths = codexAdapter.write(rendered, targetDir);
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0]).toBe(join(targetDir, "AGENTS.md"));
+    });
+
+    it("creates target directory automatically", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = codexAdapter.render(doc);
+
+      const [outPath] = codexAdapter.write(rendered, targetDir);
+      const written = readFileSync(outPath, "utf-8");
+      expect(written).toContain("laup:generated");
+    });
+
+    it("written file ends with newline", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = codexAdapter.render(doc);
+      const [outPath] = codexAdapter.write(rendered, targetDir);
+
+      const written = readFileSync(outPath, "utf-8");
+      expect(written.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("getOutputPaths()", () => {
+    it("returns expected path", () => {
+      const paths = codexAdapter.getOutputPaths("/project");
+      expect(paths).toEqual(["/project/AGENTS.md"]);
+    });
+  });
+
+  it("adapter is a singleton export", () => {
+    expect(codexAdapter).toBeInstanceOf(CodexAdapter);
+  });
+});

--- a/packages/adapters/codex/src/index.ts
+++ b/packages/adapters/codex/src/index.ts
@@ -1,0 +1,36 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CanonicalInstruction, ToolAdapter } from "@laup/core";
+
+/**
+ * OpenAI Codex CLI adapter — renders canonical instruction to AGENTS.md.
+ * See: https://agents.md
+ * See: https://developers.openai.com/codex
+ */
+export class CodexAdapter implements ToolAdapter {
+  readonly toolId = "codex";
+  readonly displayName = "Codex CLI";
+  readonly category = "cli" as const;
+
+  render(doc: CanonicalInstruction): string {
+    const lines: string[] = [
+      "<!-- laup:generated — do not edit directly, edit laup.md instead -->",
+      "",
+      doc.body,
+    ];
+    return lines.join("\n").trimEnd();
+  }
+
+  write(rendered: string, targetDir: string): string[] {
+    mkdirSync(targetDir, { recursive: true });
+    const outPath = join(targetDir, "AGENTS.md");
+    writeFileSync(outPath, `${rendered}\n`, "utf-8");
+    return [outPath];
+  }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, "AGENTS.md")];
+  }
+}
+
+export const codexAdapter = new CodexAdapter();

--- a/packages/adapters/codex/tsconfig.json
+++ b/packages/adapters/codex/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"],
+  "references": [
+    {
+      "path": "../../core"
+    }
+  ]
+}

--- a/packages/adapters/copilot/package.json
+++ b/packages/adapters/copilot/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@laup/copilot",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "*",
+    "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "@laup/core": "workspace:*"
+  }
+}

--- a/packages/adapters/copilot/src/__tests__/golden/canonical-input.md
+++ b/packages/adapters/copilot/src/__tests__/golden/canonical-input.md
@@ -1,0 +1,14 @@
+---
+version: "1.0"
+scope: project
+---
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/copilot/src/__tests__/golden/expected-output.md
+++ b/packages/adapters/copilot/src/__tests__/golden/expected-output.md
@@ -1,0 +1,11 @@
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/copilot/src/__tests__/index.test.ts
+++ b/packages/adapters/copilot/src/__tests__/index.test.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCanonicalString } from "@laup/core";
+import { describe, expect, it } from "vitest";
+import { CopilotAdapter, copilotAdapter } from "../index.js";
+
+const fixture = (name: string) => readFileSync(join(import.meta.dirname, "golden", name), "utf-8");
+
+describe("CopilotAdapter", () => {
+  it("has correct toolId and displayName", () => {
+    expect(copilotAdapter.toolId).toBe("copilot");
+    expect(copilotAdapter.displayName).toBe("GitHub Copilot");
+  });
+
+  it("has category 'ide'", () => {
+    expect(copilotAdapter.category).toBe("ide");
+  });
+
+  describe("render()", () => {
+    it("golden-file: renders canonical input to expected output", () => {
+      const input = fixture("canonical-input.md");
+      const expected = fixture("expected-output.md");
+      const doc = parseCanonicalString(input);
+      expect(copilotAdapter.render(doc)).toBe(expected.trimEnd());
+    });
+
+    it("prepends the generated-file comment header", () => {
+      const doc = parseCanonicalString("# Body\n\nSome text.");
+      expect(copilotAdapter.render(doc)).toMatch(/^<!-- laup:generated/);
+    });
+
+    it("preserves the full body content", () => {
+      const body = "# My Rules\n\nDo the thing.";
+      const doc = parseCanonicalString(body);
+      expect(copilotAdapter.render(doc)).toContain(body);
+    });
+
+    it("does not include trailing whitespace", () => {
+      const doc = parseCanonicalString("# Body\n\nText.\n\n\n");
+      expect(copilotAdapter.render(doc)).not.toMatch(/\s+$/);
+    });
+  });
+
+  describe("write()", () => {
+    it("writes to .github/copilot-instructions.md", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = copilotAdapter.render(doc);
+
+      const paths = copilotAdapter.write(rendered, targetDir);
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0]).toBe(join(targetDir, ".github", "copilot-instructions.md"));
+    });
+
+    it("creates .github directory automatically", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = copilotAdapter.render(doc);
+
+      const [outPath] = copilotAdapter.write(rendered, targetDir);
+      const written = readFileSync(outPath, "utf-8");
+      expect(written).toContain("laup:generated");
+    });
+
+    it("written file ends with newline", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = copilotAdapter.render(doc);
+      const [outPath] = copilotAdapter.write(rendered, targetDir);
+
+      const written = readFileSync(outPath, "utf-8");
+      expect(written.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("getOutputPaths()", () => {
+    it("returns expected path", () => {
+      const paths = copilotAdapter.getOutputPaths("/project");
+      expect(paths).toEqual(["/project/.github/copilot-instructions.md"]);
+    });
+  });
+
+  it("adapter is a singleton export", () => {
+    expect(copilotAdapter).toBeInstanceOf(CopilotAdapter);
+  });
+});

--- a/packages/adapters/copilot/src/index.ts
+++ b/packages/adapters/copilot/src/index.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CanonicalInstruction, ToolAdapter } from "@laup/core";
+
+/**
+ * GitHub Copilot adapter — renders canonical instruction to .github/copilot-instructions.md.
+ * See: https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot
+ */
+export class CopilotAdapter implements ToolAdapter {
+  readonly toolId = "copilot";
+  readonly displayName = "GitHub Copilot";
+  readonly category = "ide" as const;
+
+  render(doc: CanonicalInstruction): string {
+    const lines: string[] = [
+      "<!-- laup:generated — do not edit directly, edit laup.md instead -->",
+      "",
+      doc.body,
+    ];
+    return lines.join("\n").trimEnd();
+  }
+
+  write(rendered: string, targetDir: string): string[] {
+    const githubDir = join(targetDir, ".github");
+    mkdirSync(githubDir, { recursive: true });
+
+    const outPath = join(githubDir, "copilot-instructions.md");
+    writeFileSync(outPath, `${rendered}\n`, "utf-8");
+    return [outPath];
+  }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, ".github", "copilot-instructions.md")];
+  }
+}
+
+export const copilotAdapter = new CopilotAdapter();

--- a/packages/adapters/copilot/tsconfig.json
+++ b/packages/adapters/copilot/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"],
+  "references": [
+    {
+      "path": "../../core"
+    }
+  ]
+}

--- a/packages/adapters/opencode/package.json
+++ b/packages/adapters/opencode/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@laup/opencode",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "*",
+    "vitest": "^4.0.18"
+  },
+  "dependencies": {
+    "@laup/core": "workspace:*"
+  }
+}

--- a/packages/adapters/opencode/src/__tests__/golden/canonical-input.md
+++ b/packages/adapters/opencode/src/__tests__/golden/canonical-input.md
@@ -1,0 +1,19 @@
+---
+version: "1.0"
+scope: project
+tools:
+  opencode:
+    model: "claude-3.7-sonnet"
+    maxTokens: 5000
+    autoCompact: true
+---
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/opencode/src/__tests__/golden/expected-agents.md
+++ b/packages/adapters/opencode/src/__tests__/golden/expected-agents.md
@@ -1,0 +1,11 @@
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+# Test Project Instructions
+
+Always use TypeScript strict mode.
+Prefer functional patterns over class-based patterns.
+
+## Code Style
+
+- Use `const` over `let`; never use `var`
+- Prefer explicit return types on public functions

--- a/packages/adapters/opencode/src/__tests__/golden/expected-config.json
+++ b/packages/adapters/opencode/src/__tests__/golden/expected-config.json
@@ -1,0 +1,10 @@
+{
+  "_generated": "laup:generated — do not edit directly, edit laup.md instead",
+  "agents": {
+    "coder": {
+      "model": "claude-3.7-sonnet",
+      "maxTokens": 5000
+    }
+  },
+  "autoCompact": true
+}

--- a/packages/adapters/opencode/src/__tests__/index.test.ts
+++ b/packages/adapters/opencode/src/__tests__/index.test.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCanonicalString } from "@laup/core";
+import { describe, expect, it } from "vitest";
+import { OpenCodeAdapter, openCodeAdapter } from "../index.js";
+
+const fixture = (name: string) => readFileSync(join(import.meta.dirname, "golden", name), "utf-8");
+
+describe("OpenCodeAdapter", () => {
+  it("has correct toolId and displayName", () => {
+    expect(openCodeAdapter.toolId).toBe("opencode");
+    expect(openCodeAdapter.displayName).toBe("OpenCode");
+  });
+
+  it("has category 'cli'", () => {
+    expect(openCodeAdapter.category).toBe("cli");
+  });
+
+  describe("renderAgents()", () => {
+    it("golden-file: renders canonical input to expected AGENTS.md output", () => {
+      const input = fixture("canonical-input.md");
+      const expected = fixture("expected-agents.md");
+      const doc = parseCanonicalString(input);
+      expect(openCodeAdapter.renderAgents(doc)).toBe(expected.trimEnd());
+    });
+
+    it("prepends the generated-file comment header", () => {
+      const doc = parseCanonicalString("# Body\n\nSome text.");
+      expect(openCodeAdapter.renderAgents(doc)).toMatch(/^<!-- laup:generated/);
+    });
+
+    it("preserves the full body content", () => {
+      const body = "# My Rules\n\nDo the thing.";
+      const doc = parseCanonicalString(body);
+      expect(openCodeAdapter.renderAgents(doc)).toContain(body);
+    });
+  });
+
+  describe("renderConfig()", () => {
+    it("golden-file: renders config when overrides present", () => {
+      const input = fixture("canonical-input.md");
+      const expected = fixture("expected-config.json");
+      const doc = parseCanonicalString(input);
+      expect(openCodeAdapter.renderConfig(doc)).toBe(expected.trimEnd());
+    });
+
+    it("returns null when no opencode overrides", () => {
+      const doc = parseCanonicalString("# Body\n\nText.");
+      expect(openCodeAdapter.renderConfig(doc)).toBeNull();
+    });
+
+    it("includes model in agents.coder", () => {
+      const input = [
+        "---",
+        'version: "1.0"',
+        "tools:",
+        "  opencode:",
+        '    model: "gpt-4"',
+        "---",
+        "",
+        "# Body",
+      ].join("\n");
+      const doc = parseCanonicalString(input);
+      const configStr = openCodeAdapter.renderConfig(doc);
+      expect(configStr).not.toBeNull();
+      const config = JSON.parse(configStr as string);
+      expect(config.agents.coder.model).toBe("gpt-4");
+    });
+
+    it("includes autoCompact when specified", () => {
+      const input = [
+        "---",
+        'version: "1.0"',
+        "tools:",
+        "  opencode:",
+        "    autoCompact: false",
+        "---",
+        "",
+        "# Body",
+      ].join("\n");
+      const doc = parseCanonicalString(input);
+      const configStr = openCodeAdapter.renderConfig(doc);
+      expect(configStr).not.toBeNull();
+      const config = JSON.parse(configStr as string);
+      expect(config.autoCompact).toBe(false);
+    });
+  });
+
+  describe("render()", () => {
+    it("returns array with agents content only when no overrides", () => {
+      const doc = parseCanonicalString("# Body\n\nText.");
+      const result = openCodeAdapter.render(doc);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain("laup:generated");
+    });
+
+    it("returns array with agents and config when overrides present", () => {
+      const input = fixture("canonical-input.md");
+      const doc = parseCanonicalString(input);
+      const result = openCodeAdapter.render(doc);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toContain("laup:generated");
+      expect(result[1]).toContain("_generated");
+    });
+  });
+
+  describe("write()", () => {
+    it("writes AGENTS.md", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = openCodeAdapter.render(doc);
+
+      const paths = openCodeAdapter.write(rendered, targetDir);
+
+      expect(paths).toHaveLength(1);
+      expect(paths[0]).toBe(join(targetDir, "AGENTS.md"));
+    });
+
+    it("writes both AGENTS.md and .opencode.json when config present", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const input = fixture("canonical-input.md");
+      const doc = parseCanonicalString(input);
+      const rendered = openCodeAdapter.render(doc);
+
+      const paths = openCodeAdapter.write(rendered, targetDir);
+
+      expect(paths).toHaveLength(2);
+      expect(paths[0]).toBe(join(targetDir, "AGENTS.md"));
+      expect(paths[1]).toBe(join(targetDir, ".opencode.json"));
+    });
+
+    it("creates target directory automatically", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      const doc = parseCanonicalString("# Test\n\nBody.");
+      const rendered = openCodeAdapter.render(doc);
+
+      openCodeAdapter.write(rendered, targetDir);
+      expect(existsSync(join(targetDir, "AGENTS.md"))).toBe(true);
+    });
+
+    it("written files end with newline", () => {
+      const targetDir = join(tmpdir(), `laup-test-${randomUUID()}`);
+      mkdirSync(targetDir, { recursive: true });
+      const input = fixture("canonical-input.md");
+      const doc = parseCanonicalString(input);
+      const rendered = openCodeAdapter.render(doc);
+      openCodeAdapter.write(rendered, targetDir);
+
+      const agents = readFileSync(join(targetDir, "AGENTS.md"), "utf-8");
+      const config = readFileSync(join(targetDir, ".opencode.json"), "utf-8");
+      expect(agents.endsWith("\n")).toBe(true);
+      expect(config.endsWith("\n")).toBe(true);
+    });
+  });
+
+  describe("getOutputPaths()", () => {
+    it("returns expected paths", () => {
+      const paths = openCodeAdapter.getOutputPaths("/project");
+      expect(paths).toEqual(["/project/AGENTS.md", "/project/.opencode.json"]);
+    });
+  });
+
+  it("adapter is a singleton export", () => {
+    expect(openCodeAdapter).toBeInstanceOf(OpenCodeAdapter);
+  });
+});

--- a/packages/adapters/opencode/src/index.ts
+++ b/packages/adapters/opencode/src/index.ts
@@ -1,0 +1,119 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { CanonicalInstruction, ToolAdapter } from "@laup/core";
+
+/**
+ * OpenCode tool-specific overrides.
+ */
+interface OpenCodeOverrides {
+  model?: string;
+  maxTokens?: number;
+  autoCompact?: boolean;
+  mcpServers?: Record<string, McpServerConfig>;
+}
+
+interface McpServerConfig {
+  type: "stdio" | "http" | "sse";
+  command?: string;
+  url?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface OpenCodeConfig {
+  _generated?: string;
+  agents?: {
+    coder?: {
+      model?: string;
+      maxTokens?: number;
+    };
+  };
+  autoCompact?: boolean;
+  mcpServers?: Record<string, McpServerConfig>;
+}
+
+/**
+ * OpenCode / Crush adapter — renders canonical instruction to AGENTS.md
+ * and optionally generates .opencode.json when tool-specific overrides exist.
+ *
+ * See: https://github.com/charmbracelet/crush
+ * See: https://agents.md
+ */
+export class OpenCodeAdapter implements ToolAdapter {
+  readonly toolId = "opencode";
+  readonly displayName = "OpenCode";
+  readonly category = "cli" as const;
+
+  renderAgents(doc: CanonicalInstruction): string {
+    const lines: string[] = [
+      "<!-- laup:generated — do not edit directly, edit laup.md instead -->",
+      "",
+      doc.body,
+    ];
+    return lines.join("\n").trimEnd();
+  }
+
+  renderConfig(doc: CanonicalInstruction): string | null {
+    const overrides = doc.frontmatter.tools?.opencode as OpenCodeOverrides | undefined;
+    if (!overrides) return null;
+
+    const config: OpenCodeConfig = {
+      _generated: "laup:generated — do not edit directly, edit laup.md instead",
+    };
+
+    if (overrides.model || overrides.maxTokens) {
+      const coder: { model?: string; maxTokens?: number } = {};
+      if (overrides.model) {
+        coder.model = overrides.model;
+      }
+      if (overrides.maxTokens) {
+        coder.maxTokens = overrides.maxTokens;
+      }
+      config.agents = { coder };
+    }
+
+    if (overrides.autoCompact !== undefined) {
+      config.autoCompact = overrides.autoCompact;
+    }
+
+    if (overrides.mcpServers) {
+      config.mcpServers = overrides.mcpServers;
+    }
+
+    return JSON.stringify(config, null, 2);
+  }
+
+  /**
+   * Returns [agentsContent, configContent | null]
+   */
+  render(doc: CanonicalInstruction): string[] {
+    const agents = this.renderAgents(doc);
+    const config = this.renderConfig(doc);
+    return config ? [agents, config] : [agents];
+  }
+
+  write(rendered: string | string[], targetDir: string): string[] {
+    const [agents, config] = Array.isArray(rendered) ? rendered : [rendered, undefined];
+    const written: string[] = [];
+
+    mkdirSync(targetDir, { recursive: true });
+
+    const agentsPath = join(targetDir, "AGENTS.md");
+    writeFileSync(agentsPath, `${agents}\n`, "utf-8");
+    written.push(agentsPath);
+
+    if (config) {
+      const configPath = join(targetDir, ".opencode.json");
+      writeFileSync(configPath, `${config}\n`, "utf-8");
+      written.push(configPath);
+    }
+
+    return written;
+  }
+
+  getOutputPaths(targetDir: string): string[] {
+    return [join(targetDir, "AGENTS.md"), join(targetDir, ".opencode.json")];
+  }
+}
+
+export const openCodeAdapter = new OpenCodeAdapter();

--- a/packages/adapters/opencode/tsconfig.json
+++ b/packages/adapters/opencode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/__tests__/**"],
+  "references": [
+    {
+      "path": "../../core"
+    }
+  ]
+}

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -32,6 +32,20 @@ const GeminiOverrideSchema = z.object({
 const OpenCodeOverrideSchema = z.object({
   model: z.string().optional(),
   provider: z.string().optional(),
+  maxTokens: z.number().optional(),
+  autoCompact: z.boolean().optional(),
+  mcpServers: z
+    .record(
+      z.string(),
+      z.object({
+        type: z.enum(["stdio", "http", "sse"]),
+        command: z.string().optional(),
+        url: z.string().optional(),
+        args: z.array(z.string()).optional(),
+        env: z.record(z.string(), z.string()).optional(),
+      }),
+    )
+    .optional(),
 });
 
 const WindsurfOverrideSchema = z.object({
@@ -49,10 +63,13 @@ const DevinOverrideSchema = z.object({
 
 const CopilotOverrideSchema = z.object({});
 
+const CodexOverrideSchema = z.object({});
+
 // looseObject preserves unknown tool IDs at runtime so validate.ts can
 // detect and report them (ADR-001 §7.6, step 5 — unknown ID is a warning, not error)
 export const ToolOverridesSchema = z.looseObject({
   "claude-code": ClaudeCodeOverrideSchema.optional(),
+  codex: CodexOverrideSchema.optional(),
   copilot: CopilotOverrideSchema.optional(),
   gemini: GeminiOverrideSchema.optional(),
   opencode: OpenCodeOverrideSchema.optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,46 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
 
+  packages/adapters/codex:
+    dependencies:
+      '@laup/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      typescript:
+        specifier: '*'
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+
+  packages/adapters/copilot:
+    dependencies:
+      '@laup/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      typescript:
+        specifier: '*'
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+
   packages/adapters/cursor:
+    dependencies:
+      '@laup/core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      typescript:
+        specifier: '*'
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+
+  packages/adapters/opencode:
     dependencies:
       '@laup/core':
         specifier: workspace:*

--- a/wiki/DOC-215-adapter-requirements.md
+++ b/wiki/DOC-215-adapter-requirements.md
@@ -1,0 +1,182 @@
+# DOC-215: Tool Adapter Requirements
+
+This document specifies requirements for new tool adapters: Codex CLI, GitHub Copilot, and OpenCode.
+
+## Overview
+
+Each adapter implements the `ToolAdapter` interface to render canonical LAUP instructions to tool-native formats.
+
+```typescript
+interface ToolAdapter {
+  toolId: string;
+  displayName: string;
+  category: ToolCategory;
+  render(doc: CanonicalInstruction): string | string[];
+  write(rendered: string | string[], targetDir: string): string[];
+  getOutputPaths?(targetDir: string): string[];
+}
+```
+
+---
+
+## ADAPT-001: Codex CLI Adapter
+
+**Tool**: OpenAI Codex CLI (`@openai/codex`)
+**Category**: `cli`
+**Priority**: MUST
+
+### Output Format
+
+Codex CLI reads agent instructions from `AGENTS.md` files (per the [agents.md standard](https://agents.md)).
+
+**File**: `AGENTS.md` (repository root)
+**Format**: Plain Markdown with optional YAML frontmatter
+
+```markdown
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+# Project Instructions
+
+[canonical body content]
+```
+
+### Tool-Specific Overrides
+
+```yaml
+tools:
+  codex:
+    # No tool-specific overrides currently defined
+```
+
+### Acceptance Criteria
+
+- [ ] Renders canonical body to `AGENTS.md`
+- [ ] Includes `laup:generated` comment header
+- [ ] Passes all tests
+
+---
+
+## ADAPT-002: GitHub Copilot Adapter
+
+**Tool**: GitHub Copilot
+**Category**: `ide`
+**Priority**: MUST
+
+### Output Format
+
+Copilot reads custom instructions from `.github/copilot-instructions.md`.
+
+**File**: `.github/copilot-instructions.md`
+**Format**: Plain Markdown
+
+```markdown
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+[canonical body content]
+```
+
+### Tool-Specific Overrides
+
+```yaml
+tools:
+  copilot:
+    # Path-specific instructions (optional future enhancement)
+    # pathInstructions:
+    #   - glob: "src/**/*.ts"
+    #     file: "typescript.instructions.md"
+```
+
+### Acceptance Criteria
+
+- [ ] Renders canonical body to `.github/copilot-instructions.md`
+- [ ] Creates `.github` directory if needed
+- [ ] Includes `laup:generated` comment header
+- [ ] Passes all tests
+
+---
+
+## ADAPT-003: OpenCode Adapter
+
+**Tool**: OpenCode / Crush (charmbracelet/crush)
+**Category**: `cli`
+**Priority**: MUST
+
+### Output Format
+
+OpenCode reads agent instructions from `AGENTS.md` (same as Codex) and tool config from `.opencode.json`.
+
+**Primary File**: `AGENTS.md` (Markdown instructions)
+**Config File**: `.opencode.json` (optional, for MCP servers and model config)
+
+```markdown
+<!-- laup:generated — do not edit directly, edit laup.md instead -->
+
+[canonical body content]
+```
+
+### Tool-Specific Overrides
+
+```yaml
+tools:
+  opencode:
+    model: "claude-3.7-sonnet"
+    maxTokens: 5000
+    autoCompact: true
+    mcpServers:
+      example:
+        type: stdio
+        command: "path/to/server"
+```
+
+### Config File Generation
+
+When overrides are present, generate `.opencode.json`:
+
+```json
+{
+  "agents": {
+    "coder": {
+      "model": "claude-3.7-sonnet",
+      "maxTokens": 5000
+    }
+  },
+  "autoCompact": true,
+  "mcpServers": {}
+}
+```
+
+### Acceptance Criteria
+
+- [ ] Renders canonical body to `AGENTS.md`
+- [ ] Generates `.opencode.json` when overrides present
+- [ ] Includes `laup:generated` comment in both files
+- [ ] Passes all tests
+
+---
+
+## Shared AGENTS.md Consideration
+
+Both Codex and OpenCode use `AGENTS.md`. If both adapters are active:
+
+1. The file content should be identical (both use canonical body)
+1. Only write once (last adapter wins, or merge in registry)
+1. Consider a shared `AgentsMdAdapter` base class
+
+---
+
+## Test Requirements
+
+Each adapter requires:
+
+1. **Unit tests**: render() produces correct output
+1. **Integration tests**: write() creates files correctly
+1. **Override tests**: tool-specific overrides apply
+1. **Header tests**: `laup:generated` marker present
+
+---
+
+## Implementation Order
+
+1. ADAPT-002 (Copilot) — most distinct output format
+1. ADAPT-001 (Codex) — AGENTS.md format
+1. ADAPT-003 (OpenCode) — AGENTS.md + config file


### PR DESCRIPTION
## Summary
- Added adapter requirements doc: wiki/DOC-215-adapter-requirements.md
- Created and implemented:
  - ADAPT-001 Codex adapter (AGENTS.md)
  - ADAPT-002 Copilot adapter (.github/copilot-instructions.md)
  - ADAPT-003 OpenCode adapter (AGENTS.md + optional .opencode.json)
- Extended schema for codex and richer opencode overrides
- Added full test coverage for all 3 adapters

## Results
- 566 tests passing

Closes #148
Closes #149
Closes #150