### PR TITLE
feat(core): add Codex import detection (ADAPT-004)

### DIFF
--- a/packages/core/src/__tests__/import.test.ts
+++ b/packages/core/src/__tests__/import.test.ts
@@ -1,0 +1,49 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { detectFormat, importDocument } from "../import.js";
+
+describe("import detection", () => {
+  it("detects Codex format from AGENTS.md", () => {
+    expect(detectFormat("AGENTS.md")).toBe("codex");
+    expect(detectFormat("/repo/AGENTS.md")).toBe("codex");
+  });
+
+  it("detects Claude format from CLAUDE.md", () => {
+    expect(detectFormat("CLAUDE.md")).toBe("claude-code");
+  });
+});
+
+describe("codex import", () => {
+  it("imports AGENTS.md content as codex format", () => {
+    const dir = join(tmpdir(), `laup-import-${randomUUID()}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "AGENTS.md");
+
+    writeFileSync(
+      path,
+      "<!-- laup:generated — do not edit directly, edit laup.md instead -->\n\n# Rules\n\nDo tests first.\n",
+      "utf-8",
+    );
+
+    const result = importDocument(path);
+
+    expect(result.sourceFormat).toBe("codex");
+    expect(result.document.frontmatter.scope).toBe("project");
+    expect(result.document.body).toBe("# Rules\n\nDo tests first.");
+  });
+
+  it("supports explicit codex format", () => {
+    const dir = join(tmpdir(), `laup-import-${randomUUID()}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "random.md");
+
+    writeFileSync(path, "# Hello from Codex", "utf-8");
+
+    const result = importDocument(path, "codex");
+    expect(result.sourceFormat).toBe("codex");
+    expect(result.document.body).toBe("# Hello from Codex");
+  });
+});

--- a/packages/core/src/import.ts
+++ b/packages/core/src/import.ts
@@ -17,6 +17,7 @@ export interface ImportResult {
  */
 export type ImportFormat =
   | "claude-code"
+  | "codex"
   | "cursor"
   | "cursor-mdc"
   | "aider"
@@ -27,6 +28,7 @@ export type ImportFormat =
 
 const FORMAT_PATTERNS: Record<string, ImportFormat> = {
   "CLAUDE.md": "claude-code",
+  "AGENTS.md": "codex",
   ".cursorrules": "cursor",
   cursorrules: "cursor",
   ".windsurfrules": "windsurf",
@@ -58,6 +60,9 @@ export function detectFormat(filePath: string): ImportFormat | null {
   }
   if (name.toUpperCase() === "CLAUDE.MD" || name.toLowerCase().includes("claude.md")) {
     return "claude-code";
+  }
+  if (name.toUpperCase() === "AGENTS.MD" || name.toLowerCase().includes("agents.md")) {
+    return "codex";
   }
   if (name.toUpperCase() === "GEMINI.MD" || name.toLowerCase().includes("gemini.md")) {
     return "gemini";
@@ -100,6 +105,8 @@ export function importDocument(filePath: string, format?: ImportFormat): ImportR
   switch (detectedFormat) {
     case "claude-code":
       return importClaudeCode(content);
+    case "codex":
+      return importCodex(content);
     case "cursor":
       return importCursor(content);
     case "cursor-mdc":
@@ -161,6 +168,23 @@ function importClaudeCode(content: string): ImportResult {
     },
     warnings,
     sourceFormat: "claude-code",
+  };
+}
+
+/**
+ * Import from AGENTS.md (Codex) format.
+ */
+function importCodex(content: string): ImportResult {
+  const warnings: string[] = [];
+  const body = stripGeneratedHeader(content);
+
+  return {
+    document: {
+      frontmatter: defaultFrontmatter(),
+      body,
+    },
+    warnings,
+    sourceFormat: "codex",
   };
 }
 


### PR DESCRIPTION
## Summary
Codex adapter exports AGENTS.md, but core importer did not recognize Codex.

This PR adds Codex support to packages/core/src/import.ts.

## Changes
- Added codex to ImportFormat
- Added AGENTS.md -> codex mapping in format detection
- Added detection rule for agents.md
- Added importCodex() and switch routing in importDocument()
- Added tests in packages/core/src/__tests__/import.test.ts

## Validation
- Build passes
- Tests pass: 570 passed, 1 skipped

Closes #153