### PR TITLE
feat(config-hub): optimistic locking for canonical docs (CONF-011)

### DIFF
--- a/packages/config-hub/src/__tests__/optimistic-locking.test.ts
+++ b/packages/config-hub/src/__tests__/optimistic-locking.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { VersionConflict, VersionedDocumentStore } from "../optimistic-locking.js";
+
+const DOC = {
+  frontmatter: { version: "1.0", scope: "project" as const },
+  body: "# Test",
+};
+
+describe("VersionedDocumentStore", () => {
+  it("creates documents with version 1", () => {
+    const store = new VersionedDocumentStore();
+    const created = store.create("doc-1", "project", DOC, "alice");
+
+    expect(created.version).toBe(1);
+    expect(created.updatedBy).toBe("alice");
+  });
+
+  it("updates with matching expected version", () => {
+    const store = new VersionedDocumentStore();
+    store.create("doc-1", "project", DOC, "alice");
+
+    const updated = store.update({
+      id: "doc-1",
+      expectedVersion: 1,
+      actor: "bob",
+      document: { ...DOC, body: "# Updated" },
+    });
+
+    expect(updated.version).toBe(2);
+    expect(updated.updatedBy).toBe("bob");
+    expect(updated.document.body).toContain("Updated");
+  });
+
+  it("rejects stale expected version with VersionConflict", () => {
+    const store = new VersionedDocumentStore();
+    store.create("doc-1", "project", DOC, "alice");
+    store.update({
+      id: "doc-1",
+      expectedVersion: 1,
+      actor: "bob",
+      document: { ...DOC, body: "# Updated once" },
+    });
+
+    expect(() =>
+      store.update({
+        id: "doc-1",
+        expectedVersion: 1,
+        actor: "charlie",
+        document: { ...DOC, body: "# stale write" },
+      }),
+    ).toThrow(VersionConflict);
+  });
+
+  it("conflict error includes current version for client retry", () => {
+    const store = new VersionedDocumentStore();
+    store.create("doc-1", "project", DOC, "alice");
+    store.update({ id: "doc-1", expectedVersion: 1, actor: "bob", document: DOC });
+
+    try {
+      store.update({ id: "doc-1", expectedVersion: 1, actor: "charlie", document: DOC });
+      throw new Error("expected conflict");
+    } catch (err) {
+      expect(err).toBeInstanceOf(VersionConflict);
+      const conflict = err as VersionConflict;
+      const response = conflict.toResponse();
+      expect(response.code).toBe("VERSION_CONFLICT");
+      expect(response.currentVersion).toBe(2);
+    }
+  });
+});

--- a/packages/config-hub/src/index.ts
+++ b/packages/config-hub/src/index.ts
@@ -8,6 +8,15 @@ import { computeDiff, type DiffResult } from "./diff.js";
 export type { ValidationResult };
 export type { DiffLine, DiffResult } from "./diff.js";
 export { computeDiff, formatDiff } from "./diff.js";
+export type {
+  ConflictError,
+  UpdateRequest,
+  VersionedDocument,
+} from "./optimistic-locking.js";
+export {
+  VersionConflict,
+  VersionedDocumentStore,
+} from "./optimistic-locking.js";
 
 export interface SyncResult {
   tool: string;

--- a/packages/config-hub/src/optimistic-locking.ts
+++ b/packages/config-hub/src/optimistic-locking.ts
@@ -1,0 +1,89 @@
+import type { CanonicalInstruction } from "@laup/core";
+
+export interface VersionedDocument {
+  id: string;
+  scope: "project" | "team" | "org";
+  document: CanonicalInstruction;
+  version: number;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+export interface UpdateRequest {
+  id: string;
+  expectedVersion: number;
+  document: CanonicalInstruction;
+  actor: string;
+}
+
+export interface ConflictError {
+  code: "VERSION_CONFLICT";
+  message: string;
+  currentVersion: number;
+}
+
+export class VersionConflict extends Error {
+  readonly currentVersion: number;
+
+  constructor(currentVersion: number) {
+    super(`Version conflict. Current version is ${currentVersion}`);
+    this.name = "VersionConflict";
+    this.currentVersion = currentVersion;
+  }
+
+  toResponse(): ConflictError {
+    return {
+      code: "VERSION_CONFLICT",
+      message: this.message,
+      currentVersion: this.currentVersion,
+    };
+  }
+}
+
+export class VersionedDocumentStore {
+  private docs = new Map<string, VersionedDocument>();
+
+  create(
+    id: string,
+    scope: VersionedDocument["scope"],
+    document: CanonicalInstruction,
+    actor: string,
+  ): VersionedDocument {
+    const created: VersionedDocument = {
+      id,
+      scope,
+      document,
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      updatedBy: actor,
+    };
+    this.docs.set(id, created);
+    return created;
+  }
+
+  get(id: string): VersionedDocument | null {
+    return this.docs.get(id) ?? null;
+  }
+
+  update(request: UpdateRequest): VersionedDocument {
+    const current = this.docs.get(request.id);
+    if (!current) {
+      throw new Error(`Document not found: ${request.id}`);
+    }
+
+    if (current.version !== request.expectedVersion) {
+      throw new VersionConflict(current.version);
+    }
+
+    const updated: VersionedDocument = {
+      ...current,
+      document: request.document,
+      version: current.version + 1,
+      updatedAt: new Date().toISOString(),
+      updatedBy: request.actor,
+    };
+
+    this.docs.set(request.id, updated);
+    return updated;
+  }
+}


### PR DESCRIPTION
Implements optimistic locking primitives for canonical documents.

Includes:
- VersionedDocumentStore (in-memory) with per-document versioning
- update(expectedVersion) conflict detection
- VersionConflict error carrying current version (for 409 responses)
- Test coverage for stale/concurrent update behavior

Closes #14