### PR TITLE
feat(config-hub): append-only document audit history (CONF-012)

### DIFF
--- a/packages/config-hub/src/__tests__/audit-history.test.ts
+++ b/packages/config-hub/src/__tests__/audit-history.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { DocumentAuditHistory } from "../audit-history.js";
+
+describe("DocumentAuditHistory", () => {
+  it("records create/update/delete with actor, scope, doc id, diff", () => {
+    const audit = new DocumentAuditHistory();
+
+    const create = audit.append({
+      action: "create",
+      actor: "alice",
+      scope: "project",
+      documentId: "doc-1",
+      diff: "+ # New Document",
+    });
+
+    const update = audit.append({
+      action: "update",
+      actor: "bob",
+      scope: "project",
+      documentId: "doc-1",
+      diff: "- old\n+ new",
+    });
+
+    const del = audit.append({
+      action: "delete",
+      actor: "charlie",
+      scope: "project",
+      documentId: "doc-1",
+      diff: "- full document",
+    });
+
+    expect(create.id).toBe("audit_1");
+    expect(update.id).toBe("audit_2");
+    expect(del.id).toBe("audit_3");
+    expect(create.timestamp).toBeDefined();
+  });
+
+  it("is append-only", () => {
+    const audit = new DocumentAuditHistory();
+    audit.append({
+      action: "create",
+      actor: "alice",
+      scope: "project",
+      documentId: "doc-1",
+      diff: "+ body",
+    });
+
+    const snapshot = audit.all();
+    snapshot.length = 0;
+
+    expect(audit.all()).toHaveLength(1);
+  });
+
+  it("queries by document id", () => {
+    const audit = new DocumentAuditHistory();
+    audit.append({
+      action: "create",
+      actor: "alice",
+      scope: "project",
+      documentId: "doc-1",
+      diff: "+ body",
+    });
+    audit.append({
+      action: "create",
+      actor: "alice",
+      scope: "project",
+      documentId: "doc-2",
+      diff: "+ body",
+    });
+
+    const rows = audit.query({ documentId: "doc-1" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.documentId).toBe("doc-1");
+  });
+});

--- a/packages/config-hub/src/audit-history.ts
+++ b/packages/config-hub/src/audit-history.ts
@@ -1,0 +1,49 @@
+export type DocumentChangeAction = "create" | "update" | "delete";
+
+export interface DocumentAuditRecord {
+  id: string;
+  action: DocumentChangeAction;
+  actor: string;
+  timestamp: string;
+  scope: "project" | "team" | "org";
+  documentId: string;
+  diff: string;
+}
+
+export interface AuditQuery {
+  documentId?: string;
+  from?: string;
+  to?: string;
+}
+
+export class DocumentAuditHistory {
+  private readonly records: DocumentAuditRecord[] = [];
+
+  append(record: Omit<DocumentAuditRecord, "id" | "timestamp">): DocumentAuditRecord {
+    const created: DocumentAuditRecord = {
+      ...record,
+      id: `audit_${this.records.length + 1}`,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.records.push(created);
+    return created;
+  }
+
+  query(filters: AuditQuery = {}): DocumentAuditRecord[] {
+    const fromMs = filters.from ? new Date(filters.from).getTime() : null;
+    const toMs = filters.to ? new Date(filters.to).getTime() : null;
+
+    return this.records.filter((r) => {
+      if (filters.documentId && r.documentId !== filters.documentId) return false;
+      const t = new Date(r.timestamp).getTime();
+      if (fromMs !== null && t < fromMs) return false;
+      if (toMs !== null && t > toMs) return false;
+      return true;
+    });
+  }
+
+  all(): DocumentAuditRecord[] {
+    return [...this.records];
+  }
+}

--- a/packages/config-hub/src/index.ts
+++ b/packages/config-hub/src/index.ts
@@ -6,6 +6,8 @@ import { parseCanonical, validateCanonical } from "@laup/core";
 import { computeDiff, type DiffResult } from "./diff.js";
 
 export type { ValidationResult };
+export type { AuditQuery, DocumentAuditRecord, DocumentChangeAction } from "./audit-history.js";
+export { DocumentAuditHistory } from "./audit-history.js";
 export type { DiffLine, DiffResult } from "./diff.js";
 export { computeDiff, formatDiff } from "./diff.js";
 


### PR DESCRIPTION
Implements CONF-012 audit history primitives.

Includes:
- append-only DocumentAuditHistory store
- record fields: actor, timestamp, scope, documentId, diff, action
- query filtering by documentId and date windows
- tests for append-only + query behavior

Closes #15