### PR TITLE
fix(security): resolve open CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Lint, typecheck & test

--- a/packages/core/src/db-adapter.ts
+++ b/packages/core/src/db-adapter.ts
@@ -237,9 +237,15 @@ export class InMemoryDbAdapter extends BaseDbAdapter {
         // Simple parameter substitution
         const row: Record<string, unknown> = { id };
         if (params) {
-          const colMatch = sql.match(/\(([^)]+)\)\s+values/i);
-          if (colMatch && colMatch[1]) {
-            const cols = colMatch[1].split(",").map((c) => c.trim());
+          const lowerSql = sql.toLowerCase();
+          const valuesIdx = lowerSql.indexOf("values");
+          const openParenIdx = valuesIdx > 0 ? sql.lastIndexOf("(", valuesIdx) : -1;
+          const closeParenIdx =
+            valuesIdx > 0 && openParenIdx >= 0 ? sql.indexOf(")", openParenIdx + 1) : -1;
+
+          if (openParenIdx >= 0 && closeParenIdx > openParenIdx) {
+            const colsRaw = sql.slice(openParenIdx + 1, closeParenIdx);
+            const cols = colsRaw.split(",").map((c) => c.trim());
             cols.forEach((col, i) => {
               if (params[i] !== undefined) {
                 row[col] = params[i];

--- a/packages/core/src/handoff-schema.ts
+++ b/packages/core/src/handoff-schema.ts
@@ -358,21 +358,30 @@ function getNestedValue(obj: unknown, path: string): unknown {
 /**
  * Set nested value in object.
  */
+function isSafePathSegment(segment: string): boolean {
+  return segment !== "__proto__" && segment !== "prototype" && segment !== "constructor";
+}
+
 function setNestedValue(obj: Record<string, unknown>, path: string, value: unknown): void {
   const parts = path.split(".");
   let current: Record<string, unknown> = obj;
 
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];
-    if (part === undefined) continue;
-    if (!(part in current)) {
+    if (part === undefined || !isSafePathSegment(part)) continue;
+
+    const existing = current[part];
+    if (existing === undefined) {
       current[part] = {};
+    } else if (existing === null || typeof existing !== "object" || Array.isArray(existing)) {
+      return;
     }
+
     current = current[part] as Record<string, unknown>;
   }
 
   const lastPart = parts[parts.length - 1];
-  if (lastPart) {
+  if (lastPart && isSafePathSegment(lastPart)) {
     current[lastPart] = value;
   }
 }

--- a/packages/core/src/skill-renderer.ts
+++ b/packages/core/src/skill-renderer.ts
@@ -23,6 +23,10 @@ export interface SkillRenderer {
   getFilename(skill: Skill): string;
 }
 
+function escapeYamlDoubleQuoted(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r/g, "").replace(/\n/g, "\\n");
+}
+
 /**
  * Claude Code skill renderer.
  * Renders skills as markdown with slash command documentation.
@@ -122,7 +126,7 @@ export class CursorSkillRenderer implements SkillRenderer {
 
     // YAML frontmatter
     lines.push("---");
-    lines.push(`description: "${skill.description.replace(/"/g, '\\"')}"`);
+    lines.push(`description: "${escapeYamlDoubleQuoted(skill.description)}"`);
     if (skill.tools?.["cursor"]) {
       const cursorOverrides = skill.tools["cursor"] as Record<string, unknown>;
       if (cursorOverrides["globs"]) {


### PR DESCRIPTION
Fixes all currently open code-scanning alerts:

- actions/missing-workflow-permissions: add explicit `permissions: contents: read` in CI workflow
- js/incomplete-sanitization: harden YAML escaping in skill renderer (escape backslashes/newlines/quotes)
- js/prototype-pollution-utility + prototype-polluting-assignment: guard unsafe path segments in handoff nested assignment
- js/polynomial-redos: remove regex-based column parsing in in-memory DB adapter and replace with index-based parsing

Validation:
- build passes
- tests pass (583 passed, 1 skipped)
