### PR TITLE
feat(core): require authenticated identity for API requests (PERM-001)

### DIFF
--- a/packages/core/src/__tests__/auth/auth-middleware.test.ts
+++ b/packages/core/src/__tests__/auth/auth-middleware.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryAuditStorage } from "../../audit-storage.js";
+import { authenticateRequest } from "../../auth/auth-middleware.js";
+import { InMemoryCredentialStore, TestEncryptionProvider } from "../../credential-store.js";
+
+describe("auth middleware (PERM-001)", () => {
+  it("rejects unauthenticated requests with 401", async () => {
+    const result = await authenticateRequest(
+      { headers: {}, path: "/v1/config", method: "GET" },
+      {},
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toBe("unauthenticated");
+    }
+  });
+
+  it("authenticates API key requests", async () => {
+    const store = new InMemoryCredentialStore(new TestEncryptionProvider());
+    await store.init();
+
+    const keyId = await store.store(
+      {
+        name: "svc-key",
+        type: "api-key",
+        ownerId: "svc-1",
+        ownerType: "team",
+      },
+      "secret-123",
+    );
+
+    const result = await authenticateRequest(
+      {
+        headers: {
+          "x-api-key-id": keyId,
+          "x-api-key": "secret-123",
+        },
+        method: "POST",
+        path: "/v1/run",
+      },
+      {
+        apiKey: {
+          credentialStore: store,
+          accessor: "test",
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.method).toBe("api-key");
+      expect(result.context.identity.id).toBe("svc-1");
+    }
+  });
+
+  it("authenticates OAuth/OIDC bearer requests", async () => {
+    const result = await authenticateRequest(
+      {
+        headers: { authorization: "Bearer good-token" },
+        method: "GET",
+        path: "/v1/me",
+      },
+      {
+        oauth: {
+          verifyBearerToken: async (token) =>
+            token === "good-token"
+              ? { sub: "user-1", email: "u@example.com", scope: "read write" }
+              : null,
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.method).toBe("oauth2-oidc");
+      expect(result.context.identity.id).toBe("user-1");
+    }
+  });
+
+  it("authenticates SAML requests", async () => {
+    const result = await authenticateRequest(
+      {
+        headers: { "x-saml-assertion": "signed-assertion" },
+        method: "GET",
+        path: "/v1/sso/callback",
+      },
+      {
+        saml: {
+          verifySamlAssertion: async (assertion) =>
+            assertion === "signed-assertion"
+              ? { subject: "user-2", email: "user2@example.com", orgId: "org-1" }
+              : null,
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.context.method).toBe("saml2");
+      expect(result.context.identity.id).toBe("user-2");
+    }
+  });
+
+  it("records auth method in audit log entries", async () => {
+    const store = new InMemoryCredentialStore(new TestEncryptionProvider());
+    await store.init();
+    const keyId = await store.store(
+      { name: "svc-key", type: "api-key", ownerId: "svc-1", ownerType: "team" },
+      "secret-123",
+    );
+
+    const audit = new InMemoryAuditStorage();
+    await audit.init();
+
+    await authenticateRequest(
+      {
+        headers: { "x-api-key-id": keyId, "x-api-key": "secret-123" },
+        method: "POST",
+        path: "/v1/run",
+      },
+      {
+        apiKey: { credentialStore: store, accessor: "test" },
+        auditStorage: audit,
+      },
+    );
+
+    const page = await audit.query({ category: "auth" });
+    expect(page.entries.length).toBeGreaterThan(0);
+    expect(page.entries[0]?.metadata?.["method"]).toBe("api-key");
+  });
+});

--- a/packages/core/src/auth/api-key-auth.ts
+++ b/packages/core/src/auth/api-key-auth.ts
@@ -1,0 +1,68 @@
+import type { CredentialStore } from "../credential-store.js";
+import type { AuthResult } from "./auth-types.js";
+
+const parseApiKey = (
+  headers: Record<string, string | undefined>,
+): { keyId: string; key: string } | null => {
+  const keyId = headers["x-api-key-id"];
+  const key = headers["x-api-key"];
+  if (keyId && key) return { keyId, key };
+
+  const auth = headers["authorization"];
+  if (!auth) return null;
+  const [scheme, value] = auth.split(" ");
+  if (scheme?.toLowerCase() !== "apikey" || !value) return null;
+
+  const [parsedId, parsedKey] = value.split(":");
+  if (!parsedId || !parsedKey) return null;
+  return { keyId: parsedId, key: parsedKey };
+};
+
+export interface ApiKeyAuthOptions {
+  credentialStore: CredentialStore;
+  accessor: string;
+}
+
+export const authenticateApiKey = async (
+  headers: Record<string, string | undefined>,
+  options: ApiKeyAuthOptions,
+): Promise<AuthResult | null> => {
+  const parsed = parseApiKey(headers);
+  if (!parsed) return null;
+
+  const metadata = await options.credentialStore.getMetadata(parsed.keyId);
+  if (!metadata || metadata.type !== "api-key") {
+    return {
+      ok: false,
+      status: 401,
+      error: "invalid_credentials",
+      message: "Invalid API key",
+    };
+  }
+
+  const value = await options.credentialStore.get(parsed.keyId, options.accessor);
+  if (value !== parsed.key) {
+    return {
+      ok: false,
+      status: 401,
+      error: "invalid_credentials",
+      message: "Invalid API key",
+    };
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    context: {
+      method: "api-key",
+      identity: {
+        id: metadata.ownerId,
+        type: "service",
+        name: metadata.service ?? metadata.name,
+        roles: [],
+        scopes: metadata.allowedScopes ?? [],
+        claims: { credentialId: parsed.keyId },
+      },
+    },
+  };
+};

--- a/packages/core/src/auth/auth-middleware.ts
+++ b/packages/core/src/auth/auth-middleware.ts
@@ -1,0 +1,74 @@
+import type { AuditStorage } from "../audit-storage.js";
+import { type ApiKeyAuthOptions, authenticateApiKey } from "./api-key-auth.js";
+import type { AuthResult, RequestLike } from "./auth-types.js";
+import { authenticateOauth, type OauthAuthOptions } from "./oauth-auth.js";
+import { authenticateSaml, type SamlAuthOptions } from "./saml-auth.js";
+
+export interface AuthMiddlewareOptions {
+  apiKey?: ApiKeyAuthOptions;
+  oauth?: OauthAuthOptions;
+  saml?: SamlAuthOptions;
+  auditStorage?: AuditStorage;
+}
+
+const normalizeHeaders = (
+  headers: Record<string, string | undefined>,
+): Record<string, string | undefined> => {
+  const out: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(headers)) out[k.toLowerCase()] = v;
+  return out;
+};
+
+const auditAuth = async (
+  request: RequestLike,
+  result: AuthResult,
+  auditStorage?: AuditStorage,
+): Promise<void> => {
+  if (!auditStorage) return;
+
+  await auditStorage.append({
+    category: "auth",
+    action: result.ok ? "authenticate.success" : "authenticate.failure",
+    actor: result.ok ? result.context.identity.id : "anonymous",
+    targetType: "api-request",
+    targetId: request.path,
+    severity: result.ok ? "info" : "warning",
+    correlationId: request.requestId,
+    ipAddress: request.ipAddress,
+    userAgent: request.userAgent,
+    metadata: {
+      method: result.ok ? result.context.method : "none",
+      httpMethod: request.method,
+      path: request.path,
+      authError: result.ok ? undefined : result.error,
+    },
+  });
+};
+
+export const authenticateRequest = async (
+  request: RequestLike,
+  options: AuthMiddlewareOptions,
+): Promise<AuthResult> => {
+  const headers = normalizeHeaders(request.headers);
+
+  const attempts: Array<Promise<AuthResult | null>> = [];
+  if (options.apiKey) attempts.push(authenticateApiKey(headers, options.apiKey));
+  if (options.oauth) attempts.push(authenticateOauth(headers, options.oauth));
+  if (options.saml) attempts.push(authenticateSaml(headers, options.saml));
+
+  for (const attempt of attempts) {
+    const result = await attempt;
+    if (!result) continue;
+    await auditAuth(request, result, options.auditStorage);
+    return result;
+  }
+
+  const unauthenticated: AuthResult = {
+    ok: false,
+    status: 401,
+    error: "unauthenticated",
+    message: "Authentication required",
+  };
+  await auditAuth(request, unauthenticated, options.auditStorage);
+  return unauthenticated;
+};

--- a/packages/core/src/auth/auth-types.ts
+++ b/packages/core/src/auth/auth-types.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+export const AuthMethodSchema = z.enum(["api-key", "oauth2-oidc", "saml2"]);
+export type AuthMethod = z.infer<typeof AuthMethodSchema>;
+
+export const AuthIdentitySchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["user", "service", "system", "agent"]),
+  name: z.string().optional(),
+  email: z.string().optional(),
+  roles: z.array(z.string()).default([]),
+  scopes: z.array(z.string()).default([]),
+  orgId: z.string().optional(),
+  claims: z.record(z.string(), z.unknown()).optional(),
+});
+export type AuthIdentity = z.infer<typeof AuthIdentitySchema>;
+
+export interface AuthContext {
+  method: AuthMethod;
+  identity: AuthIdentity;
+  sessionId?: string;
+  expiresAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type AuthSuccess = {
+  ok: true;
+  status: 200;
+  context: AuthContext;
+};
+
+export type AuthFailure = {
+  ok: false;
+  status: 401;
+  error: "unauthenticated" | "invalid_credentials" | "expired";
+  message: string;
+};
+
+export type AuthResult = AuthSuccess | AuthFailure;
+
+export interface RequestLike {
+  path?: string;
+  method?: string;
+  headers: Record<string, string | undefined>;
+  ipAddress?: string;
+  userAgent?: string;
+  requestId?: string;
+}

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -1,0 +1,18 @@
+export type { ApiKeyAuthOptions } from "./api-key-auth.js";
+export { authenticateApiKey } from "./api-key-auth.js";
+export type { AuthMiddlewareOptions } from "./auth-middleware.js";
+export { authenticateRequest } from "./auth-middleware.js";
+export type {
+  AuthContext,
+  AuthFailure,
+  AuthIdentity,
+  AuthMethod,
+  AuthResult,
+  AuthSuccess,
+  RequestLike,
+} from "./auth-types.js";
+export { AuthIdentitySchema, AuthMethodSchema } from "./auth-types.js";
+export type { OauthAuthOptions, OidcClaims } from "./oauth-auth.js";
+export { authenticateOauth } from "./oauth-auth.js";
+export type { SamlAssertion, SamlAuthOptions } from "./saml-auth.js";
+export { authenticateSaml } from "./saml-auth.js";

--- a/packages/core/src/auth/oauth-auth.ts
+++ b/packages/core/src/auth/oauth-auth.ts
@@ -1,0 +1,62 @@
+import type { AuthContext, AuthResult } from "./auth-types.js";
+
+export interface OidcClaims {
+  sub: string;
+  email?: string;
+  name?: string;
+  org_id?: string;
+  scope?: string;
+  exp?: number;
+  [key: string]: unknown;
+}
+
+export interface OauthAuthOptions {
+  verifyBearerToken: (token: string) => Promise<OidcClaims | null>;
+}
+
+const parseBearer = (headers: Record<string, string | undefined>): string | null => {
+  const auth = headers["authorization"];
+  if (!auth) return null;
+  const [scheme, token] = auth.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) return null;
+  return token;
+};
+
+export const authenticateOauth = async (
+  headers: Record<string, string | undefined>,
+  options: OauthAuthOptions,
+): Promise<AuthResult | null> => {
+  const token = parseBearer(headers);
+  if (!token) return null;
+
+  const claims = await options.verifyBearerToken(token);
+  if (!claims) {
+    return {
+      ok: false,
+      status: 401,
+      error: "invalid_credentials",
+      message: "Invalid OAuth/OIDC token",
+    };
+  }
+
+  if (claims.exp && claims.exp * 1000 < Date.now()) {
+    return { ok: false, status: 401, error: "expired", message: "OAuth/OIDC token expired" };
+  }
+
+  const context: AuthContext = {
+    method: "oauth2-oidc",
+    identity: {
+      id: claims.sub,
+      type: "user",
+      roles: [],
+      scopes: typeof claims.scope === "string" ? claims.scope.split(" ").filter(Boolean) : [],
+      claims,
+      ...(claims.name ? { name: claims.name } : {}),
+      ...(claims.email ? { email: claims.email } : {}),
+      ...(claims.org_id ? { orgId: claims.org_id } : {}),
+    },
+    ...(claims.exp ? { expiresAt: new Date(claims.exp * 1000).toISOString() } : {}),
+  };
+
+  return { ok: true, status: 200, context };
+};

--- a/packages/core/src/auth/saml-auth.ts
+++ b/packages/core/src/auth/saml-auth.ts
@@ -1,0 +1,59 @@
+import type { AuthContext, AuthResult } from "./auth-types.js";
+
+export interface SamlAssertion {
+  subject: string;
+  email?: string;
+  name?: string;
+  orgId?: string;
+  roles?: string[];
+  attributes?: Record<string, unknown>;
+  sessionIndex?: string;
+  expiresAt?: string;
+}
+
+export interface SamlAuthOptions {
+  verifySamlAssertion: (assertion: string) => Promise<SamlAssertion | null>;
+}
+
+const parseSaml = (headers: Record<string, string | undefined>): string | null =>
+  headers["x-saml-assertion"] ?? null;
+
+export const authenticateSaml = async (
+  headers: Record<string, string | undefined>,
+  options: SamlAuthOptions,
+): Promise<AuthResult | null> => {
+  const assertion = parseSaml(headers);
+  if (!assertion) return null;
+
+  const parsed = await options.verifySamlAssertion(assertion);
+  if (!parsed) {
+    return {
+      ok: false,
+      status: 401,
+      error: "invalid_credentials",
+      message: "Invalid SAML assertion",
+    };
+  }
+
+  if (parsed.expiresAt && Date.parse(parsed.expiresAt) < Date.now()) {
+    return { ok: false, status: 401, error: "expired", message: "SAML assertion expired" };
+  }
+
+  const context: AuthContext = {
+    method: "saml2",
+    identity: {
+      id: parsed.subject,
+      type: "user",
+      roles: parsed.roles ?? [],
+      scopes: [],
+      ...(parsed.name ? { name: parsed.name } : {}),
+      ...(parsed.email ? { email: parsed.email } : {}),
+      ...(parsed.orgId ? { orgId: parsed.orgId } : {}),
+      ...(parsed.attributes ? { claims: parsed.attributes } : {}),
+    },
+    ...(parsed.sessionIndex ? { sessionId: parsed.sessionIndex } : {}),
+    ...(parsed.expiresAt ? { expiresAt: parsed.expiresAt } : {}),
+  };
+
+  return { ok: true, status: 200, context };
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,29 @@ export {
   SqlAuditStorage,
 } from "./audit-storage.js";
 export type {
+  ApiKeyAuthOptions,
+  AuthContext,
+  AuthFailure,
+  AuthIdentity,
+  AuthMethod,
+  AuthMiddlewareOptions,
+  AuthResult,
+  AuthSuccess,
+  OauthAuthOptions,
+  OidcClaims,
+  RequestLike,
+  SamlAssertion,
+  SamlAuthOptions,
+} from "./auth/index.js";
+export {
+  AuthIdentitySchema,
+  AuthMethodSchema,
+  authenticateApiKey,
+  authenticateOauth,
+  authenticateRequest,
+  authenticateSaml,
+} from "./auth/index.js";
+export type {
   Cache,
   CacheOptions,
   CacheStats,


### PR DESCRIPTION
## Summary
Implements PERM-001 by adding a reusable authentication layer that enforces authenticated identity for API requests.

## What’s included
- `packages/core/src/auth/auth-types.ts`
  - shared auth result/context/identity types and auth-method enum
- `packages/core/src/auth/api-key-auth.ts`
  - API key auth via `x-api-key-id` + `x-api-key` or `Authorization: ApiKey <id:key>`
- `packages/core/src/auth/oauth-auth.ts`
  - OAuth2/OIDC bearer token flow with pluggable verifier callback
- `packages/core/src/auth/saml-auth.ts`
  - SAML assertion flow with pluggable verifier callback
- `packages/core/src/auth/auth-middleware.ts`
  - unified `authenticateRequest(...)`
  - returns 401 for unauthenticated requests
  - records auth method/failure in audit metadata
- `packages/core/src/auth/index.ts` and package-level exports in `packages/core/src/index.ts`

## Tests
- `packages/core/src/__tests__/auth/auth-middleware.test.ts`
  - unauthenticated -> 401
  - API key success
  - OAuth/OIDC success
  - SAML success
  - auth method recorded in audit log metadata

## Validation
- `pnpm -C packages/core run build`
- `pnpm test`

Closes #54
