### PR TITLE
feat(core): PERM-003 built-in RBAC roles

### DIFF
--- a/packages/core/src/__tests__/policy/rbac.test.ts
+++ b/packages/core/src/__tests__/policy/rbac.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AuthIdentity,
+  createEvaluationContext,
+  createIdentityRolePolicies,
+  createRolePolicies,
+  type EvaluationContext,
+  PolicyEvaluator,
+  resolveBuiltInRoles,
+  resolveIdentityRoles,
+  type ScopeChainEntry,
+} from "../../index.js";
+
+describe("RBAC (PERM-003)", () => {
+  const createScopeChain = (): ScopeChainEntry[] => [
+    { scope: "user", id: "user-1" },
+    { scope: "project", id: "proj-1" },
+    { scope: "team", id: "team-1" },
+    { scope: "org", id: "org-1" },
+  ];
+
+  const createContext = (action: string): EvaluationContext =>
+    createEvaluationContext(
+      { id: "user-1", type: "user" },
+      action,
+      { type: "document" },
+      createScopeChain(),
+    );
+
+  describe("role resolution", () => {
+    it("normalizes, filters, de-duplicates, and sorts roles deterministically", () => {
+      const resolved = resolveBuiltInRoles([" Admin", "viewer", "OWNER", "admin", "unknown"]);
+      expect(resolved).toEqual(["viewer", "admin", "owner"]);
+    });
+
+    it("resolves roles from auth identity", () => {
+      const identity: AuthIdentity = {
+        id: "user-1",
+        type: "user",
+        roles: ["EDITOR", "viewer", "editor"],
+        scopes: [],
+      };
+
+      expect(resolveIdentityRoles(identity)).toEqual(["viewer", "editor"]);
+    });
+  });
+
+  describe("role -> policy mapping", () => {
+    it("creates deterministic policy IDs and allow rules", () => {
+      const policies = createRolePolicies(["editor", "viewer"], {
+        scope: "user",
+        scopeId: "user-1",
+      });
+
+      expect(policies.map((p) => p.id)).toEqual([
+        "rbac:user:user-1:viewer",
+        "rbac:user:user-1:editor",
+      ]);
+      expect(policies.every((p) => p.effect === "allow")).toBe(true);
+    });
+
+    it("creates identity-scoped policies by default", () => {
+      const policies = createIdentityRolePolicies({
+        id: "user-123",
+        roles: ["viewer"],
+      });
+
+      expect(policies[0]?.scope).toBe("user");
+      expect(policies[0]?.scopeId).toBe("user-123");
+    });
+  });
+
+  describe("allow/deny behavior by role", () => {
+    const evaluate = (roles: string[], action: string) => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext(action);
+      const policies = createRolePolicies(roles, {
+        scope: "user",
+        scopeId: "user-1",
+      });
+      return evaluator.evaluate(context, policies);
+    };
+
+    it("viewer: allows read, denies write", () => {
+      expect(evaluate(["viewer"], "read").allowed).toBe(true);
+      expect(evaluate(["viewer"], "write").allowed).toBe(false);
+    });
+
+    it("editor: allows write, denies delete", () => {
+      expect(evaluate(["editor"], "write").allowed).toBe(true);
+      expect(evaluate(["editor"], "delete").allowed).toBe(false);
+    });
+
+    it("admin: allows delete and admin", () => {
+      expect(evaluate(["admin"], "delete").allowed).toBe(true);
+      expect(evaluate(["admin"], "admin").allowed).toBe(true);
+    });
+
+    it("owner: allows everything", () => {
+      expect(evaluate(["owner"], "read").allowed).toBe(true);
+      expect(evaluate(["owner"], "write").allowed).toBe(true);
+      expect(evaluate(["owner"], "delete").allowed).toBe(true);
+      expect(evaluate(["owner"], "super-admin-action").allowed).toBe(true);
+    });
+  });
+
+  describe("interaction with policy evaluator", () => {
+    it("org deny overrides RBAC role allow due to scope priority", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("write");
+
+      const rolePolicies = createRolePolicies(["editor"], {
+        scope: "user",
+        scopeId: "user-1",
+      });
+
+      const result = evaluator.evaluate(context, [
+        ...rolePolicies,
+        {
+          id: "org-deny-write",
+          name: "Org deny write",
+          scope: "org",
+          scopeId: "org-1",
+          effect: "deny",
+          actions: ["write"],
+          resourceTypes: ["*"],
+        },
+      ]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason.matchedPolicyId).toBe("org-deny-write");
+    });
+
+    it("additional allow policies can grant actions not in RBAC role", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("delete");
+
+      const rolePolicies = createRolePolicies(["viewer"], {
+        scope: "user",
+        scopeId: "user-1",
+      });
+
+      const result = evaluator.evaluate(context, [
+        ...rolePolicies,
+        {
+          id: "project-allow-delete",
+          name: "Project allow delete",
+          scope: "project",
+          scopeId: "proj-1",
+          effect: "allow",
+          actions: ["delete"],
+          resourceTypes: ["*"],
+        },
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("project-allow-delete");
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -216,6 +216,7 @@ export type { FieldIssue } from "./parse.js";
 export { ParseError, parseCanonical, parseCanonicalString } from "./parse.js";
 export type {
   Actor,
+  BuiltInRole,
   CanonicalPolicyCondition,
   CanonicalPolicyDocument,
   CanonicalPolicyEffect,
@@ -241,13 +242,18 @@ export type {
   PolicyScope,
   PolicyValidationResult,
   Resource,
+  RolePolicyOptions,
   ScopeChainEntry,
 } from "./policy/index.js";
 export {
+  BUILT_IN_ROLES,
+  BuiltInRoleSchema,
   createEvaluationContext,
   createFailClosedEvaluator,
   createFailOpenEvaluator,
+  createIdentityRolePolicies,
   createPermissionAuditLogger,
+  createRolePolicies,
   evaluatePolicyWithAudit,
   MatchedRuleSchema,
   matchesGlob,
@@ -262,6 +268,8 @@ export {
   PolicyRuleSchema,
   PolicyScopeSchema,
   permissionEvaluation,
+  resolveBuiltInRoles,
+  resolveIdentityRoles,
   validatePolicyDocument,
   validatePolicyJson,
   validatePolicyYaml,

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -67,3 +67,12 @@ export {
   validatePolicyJson,
   validatePolicyYaml,
 } from "./policy-validator.js";
+export type { BuiltInRole, RolePolicyOptions } from "./rbac.js";
+export {
+  BUILT_IN_ROLES,
+  BuiltInRoleSchema,
+  createIdentityRolePolicies,
+  createRolePolicies,
+  resolveBuiltInRoles,
+  resolveIdentityRoles,
+} from "./rbac.js";

--- a/packages/core/src/policy/rbac.ts
+++ b/packages/core/src/policy/rbac.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+import type { AuthIdentity } from "../auth/auth-types.js";
+import type { PolicyScope } from "./evaluation-context.js";
+import type { Policy } from "./policy-evaluator.js";
+
+/**
+ * Built-in RBAC roles (PERM-003), ordered by ascending privilege.
+ */
+export const BUILT_IN_ROLES = ["viewer", "editor", "admin", "owner"] as const;
+export type BuiltInRole = (typeof BUILT_IN_ROLES)[number];
+
+export const BuiltInRoleSchema = z.enum(BUILT_IN_ROLES);
+
+const ROLE_PRIORITY: Record<BuiltInRole, number> = {
+  viewer: 0,
+  editor: 1,
+  admin: 2,
+  owner: 3,
+};
+
+/**
+ * Built-in role -> granted action patterns.
+ *
+ * Role intent:
+ * - viewer: read-only access
+ * - editor: read/write access
+ * - admin: read/write/delete + administrative actions
+ * - owner: full access
+ */
+const ROLE_ACTIONS: Record<BuiltInRole, string[]> = {
+  viewer: ["read"],
+  editor: ["read", "write"],
+  admin: ["read", "write", "delete", "admin"],
+  owner: ["*"],
+};
+
+/**
+ * Resolve and normalize built-in roles deterministically.
+ * - trims and lowercases
+ * - filters unknown roles
+ * - de-duplicates
+ * - sorts by privilege (viewer -> owner)
+ */
+export function resolveBuiltInRoles(roles: readonly string[]): BuiltInRole[] {
+  const resolved = new Set<BuiltInRole>();
+
+  for (const role of roles) {
+    const normalized = role.trim().toLowerCase();
+    const parsed = BuiltInRoleSchema.safeParse(normalized);
+    if (parsed.success) {
+      resolved.add(parsed.data);
+    }
+  }
+
+  return [...resolved].sort((a, b) => ROLE_PRIORITY[a] - ROLE_PRIORITY[b]);
+}
+
+/**
+ * Resolve built-in roles from an authenticated identity.
+ */
+export function resolveIdentityRoles(identity: Pick<AuthIdentity, "roles">): BuiltInRole[] {
+  return resolveBuiltInRoles(identity.roles);
+}
+
+export interface RolePolicyOptions {
+  scope: PolicyScope;
+  scopeId: string;
+  resourceTypes?: string[];
+  priority?: number;
+  enabled?: boolean;
+}
+
+/**
+ * Build deterministic allow policies from built-in roles.
+ */
+export function createRolePolicies(roles: readonly string[], options: RolePolicyOptions): Policy[] {
+  const resolvedRoles = resolveBuiltInRoles(roles);
+  const resourceTypes = options.resourceTypes ?? ["*"];
+
+  return resolvedRoles.map((role) => ({
+    id: `rbac:${options.scope}:${options.scopeId}:${role}`,
+    name: `RBAC ${role}`,
+    description: `Built-in ${role} role permission policy`,
+    scope: options.scope,
+    scopeId: options.scopeId,
+    effect: "allow",
+    actions: ROLE_ACTIONS[role],
+    resourceTypes,
+    ...(options.priority !== undefined ? { priority: options.priority } : {}),
+    ...(options.enabled !== undefined ? { enabled: options.enabled } : {}),
+  }));
+}
+
+/**
+ * Build role policies directly from an authenticated identity.
+ * Uses user scope and identity.id by default.
+ */
+export function createIdentityRolePolicies(
+  identity: Pick<AuthIdentity, "id" | "roles">,
+  options: Omit<RolePolicyOptions, "scope" | "scopeId"> & {
+    scope?: PolicyScope;
+    scopeId?: string;
+  } = {},
+): Policy[] {
+  return createRolePolicies(identity.roles, {
+    scope: options.scope ?? "user",
+    scopeId: options.scopeId ?? identity.id,
+    ...(options.resourceTypes !== undefined ? { resourceTypes: options.resourceTypes } : {}),
+    ...(options.priority !== undefined ? { priority: options.priority } : {}),
+    ...(options.enabled !== undefined ? { enabled: options.enabled } : {}),
+  });
+}


### PR DESCRIPTION
## Summary
- implement PERM-003 RBAC support with four built-in roles: `viewer`, `editor`, `admin`, `owner`
- add deterministic role resolution helpers (normalize/filter/dedupe/sort)
- map built-in roles to policy-evaluator-compatible allow policies
- add identity-based helper to generate role policies from auth identities
- export RBAC APIs from `policy` and `core` indexes
- add tests for role resolution, allow/deny by role, and interaction with existing policy evaluation precedence

## Built-in role mappings
- `viewer` -> `read`
- `editor` -> `read`, `write`
- `admin` -> `read`, `write`, `delete`, `admin`
- `owner` -> `*`

## Validation
- `pnpm build`
- `pnpm test:run`

Closes #56
