### PR TITLE
feat(core): implement PERM-007 conditional permission rules

### DIFF
--- a/packages/core/src/__tests__/policy/policy-evaluator.test.ts
+++ b/packages/core/src/__tests__/policy/policy-evaluator.test.ts
@@ -625,6 +625,140 @@ describe("PolicyEvaluator", () => {
     });
   });
 
+  describe("PERM-007 conditional dimensions", () => {
+    it("supports role dimension", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("write");
+      context.actor.attributes = { roles: ["editor", "viewer"] };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "editor-write",
+          conditions: [{ field: "roles", operator: "contains", value: "editor" }],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("editor-write");
+    });
+
+    it("supports project dimension", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("read");
+      context.environment = { project: "payments" };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "project-payments",
+          conditions: [{ field: "project", operator: "eq", value: "payments" }],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("project-payments");
+    });
+
+    it("supports branch dimension", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("read");
+      context.environment = { branch: "feature/perm-007" };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "feature-branches",
+          conditions: [{ field: "branch", operator: "regex", value: "^feature/" }],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("feature-branches");
+    });
+
+    it("supports tool dimension", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("execute", "tool-call");
+      context.environment = { tool: "exec" };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "allow-exec",
+          conditions: [{ field: "tool", operator: "eq", value: "exec" }],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("allow-exec");
+    });
+
+    it("supports day + time window dimensions", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("write");
+      context.environment = {
+        timestamp: "2026-03-02T15:30:00Z", // Monday 15:30 UTC
+      };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "business-hours",
+          conditions: [
+            { field: "day", operator: "in", value: ["mon", "tue", "wed", "thu", "fri"] },
+            { field: "timeWindow", operator: "eq", value: "09:00-17:00" },
+          ],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("business-hours");
+    });
+
+    it("supports combined dimensions and preserves deny precedence", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("execute", "tool-call");
+      context.actor.attributes = { roles: ["editor"] };
+      context.environment = {
+        project: "payments",
+        branch: "main",
+        tool: "exec",
+        timestamp: "2026-03-02T20:15:00Z", // Monday, outside 09:00-17:00
+      };
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "project-allow",
+          effect: "allow",
+          scope: "project",
+          scopeId: "proj-1",
+          actions: ["execute"],
+          resourceTypes: ["tool-call"],
+          conditions: [
+            { field: "roles", operator: "contains", value: "editor" },
+            { field: "project", operator: "eq", value: "payments" },
+            { field: "branch", operator: "eq", value: "main" },
+            { field: "tool", operator: "eq", value: "exec" },
+          ],
+        }),
+        createPolicy({
+          id: "org-deny-after-hours",
+          effect: "deny",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["execute"],
+          resourceTypes: ["tool-call"],
+          conditions: [
+            { field: "day", operator: "in", value: ["mon", "tue", "wed", "thu", "fri"] },
+            { field: "timeWindow", operator: "eq", value: "17:01-08:59" },
+          ],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.effect).toBe("deny");
+      expect(result.reason.matchedPolicyId).toBe("org-deny-after-hours");
+      expect(result.reason.denyCount).toBe(1);
+      expect(result.reason.allowCount).toBe(1);
+    });
+  });
+
   describe("evaluation consistency and determinism", () => {
     it("produces same result for same input", () => {
       const evaluator = new PolicyEvaluator();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,6 +222,7 @@ export type {
   CanonicalPolicyEffect,
   CanonicalPolicyRule,
   CanonicalPolicyScope,
+  ConditionalDimensions,
   DefaultEffect,
   EmergencyKillSwitchConfig,
   EvaluationContext,
@@ -254,6 +255,7 @@ export type {
 export {
   BUILT_IN_ROLES,
   BuiltInRoleSchema,
+  conditionsMatch,
   createEmergencyKillSwitch,
   createEvaluationContext,
   createFailClosedEvaluator,
@@ -261,6 +263,7 @@ export {
   createIdentityRolePolicies,
   createPermissionAuditLogger,
   createRolePolicies,
+  deriveConditionalDimensions,
   EmergencyKillSwitch,
   evaluatePolicyWithAudit,
   KillSwitchBlockedError,

--- a/packages/core/src/policy/condition-evaluator.ts
+++ b/packages/core/src/policy/condition-evaluator.ts
@@ -1,0 +1,226 @@
+import type { EvaluationContext } from "./evaluation-context.js";
+import type { PolicyCondition } from "./policy-evaluator.js";
+
+export interface ConditionalDimensions {
+  role?: string;
+  roles?: string[];
+  project?: string;
+  branch?: string;
+  tool?: string;
+  day?: string;
+  time?: string;
+  timeMinutes?: number;
+}
+
+const DAY_LABELS = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+const pad2 = (value: number): string => value.toString().padStart(2, "0");
+
+const parseTimeMinutes = (value: string): number | null => {
+  const match = /^(\d{2}):(\d{2})$/.exec(value.trim());
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  return hours * 60 + minutes;
+};
+
+const matchesTimeWindow = (timeMinutes: number | undefined, expected: unknown): boolean => {
+  if (timeMinutes === undefined) return false;
+
+  const windows = Array.isArray(expected) ? expected : [expected];
+  for (const windowValue of windows) {
+    if (typeof windowValue !== "string") {
+      continue;
+    }
+
+    const [startRaw, endRaw] = windowValue.split("-");
+    if (!startRaw || !endRaw) {
+      continue;
+    }
+
+    const start = parseTimeMinutes(startRaw);
+    const end = parseTimeMinutes(endRaw);
+    if (start === null || end === null) {
+      continue;
+    }
+
+    if (start <= end) {
+      if (timeMinutes >= start && timeMinutes <= end) {
+        return true;
+      }
+      continue;
+    }
+
+    // Overnight window, e.g. 22:00-04:00
+    if (timeMinutes >= start || timeMinutes <= end) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const getFieldValue = (
+  field: string,
+  context: EvaluationContext,
+  dimensions: ConditionalDimensions,
+): unknown => {
+  const fromDimensions = dimensions[field as keyof ConditionalDimensions];
+  if (fromDimensions !== undefined) {
+    return fromDimensions;
+  }
+
+  const parts = field.split(".");
+  let value: unknown = context;
+
+  for (const part of parts) {
+    if (value === null || value === undefined) {
+      return undefined;
+    }
+
+    if (typeof value !== "object") {
+      return undefined;
+    }
+
+    value = (value as Record<string, unknown>)[part];
+  }
+
+  return value;
+};
+
+const evaluateCondition = (
+  condition: PolicyCondition,
+  context: EvaluationContext,
+  dimensions: ConditionalDimensions,
+): boolean => {
+  const fieldValue = getFieldValue(condition.field, context, dimensions);
+
+  if (condition.field === "timeWindow") {
+    return matchesTimeWindow(dimensions.timeMinutes, condition.value);
+  }
+
+  switch (condition.operator) {
+    case "eq":
+      return fieldValue === condition.value;
+    case "neq":
+      return fieldValue !== condition.value;
+    case "in":
+      return Array.isArray(condition.value) && condition.value.includes(fieldValue as never);
+    case "nin":
+      return Array.isArray(condition.value) && !condition.value.includes(fieldValue as never);
+    case "contains":
+      return Array.isArray(fieldValue)
+        ? fieldValue.includes(condition.value as never)
+        : typeof fieldValue === "string" && typeof condition.value === "string"
+          ? fieldValue.includes(condition.value)
+          : false;
+    case "exists":
+      return condition.value ? fieldValue !== undefined : fieldValue === undefined;
+    case "regex":
+      return typeof fieldValue === "string" && typeof condition.value === "string"
+        ? new RegExp(condition.value).test(fieldValue)
+        : false;
+    case "gt":
+      return (
+        typeof fieldValue === "number" &&
+        typeof condition.value === "number" &&
+        fieldValue > condition.value
+      );
+    case "gte":
+      return (
+        typeof fieldValue === "number" &&
+        typeof condition.value === "number" &&
+        fieldValue >= condition.value
+      );
+    case "lt":
+      return (
+        typeof fieldValue === "number" &&
+        typeof condition.value === "number" &&
+        fieldValue < condition.value
+      );
+    case "lte":
+      return (
+        typeof fieldValue === "number" &&
+        typeof condition.value === "number" &&
+        fieldValue <= condition.value
+      );
+    default:
+      return false;
+  }
+};
+
+export function deriveConditionalDimensions(context: EvaluationContext): ConditionalDimensions {
+  const actorAttrs = context.actor.attributes ?? {};
+  const env = context.environment ?? {};
+
+  const roles = Array.isArray(actorAttrs["roles"])
+    ? actorAttrs["roles"].filter((value): value is string => typeof value === "string")
+    : [];
+
+  const role =
+    typeof actorAttrs["role"] === "string"
+      ? actorAttrs["role"]
+      : roles.length > 0
+        ? roles[0]
+        : typeof env["role"] === "string"
+          ? env["role"]
+          : undefined;
+
+  const project =
+    typeof env["project"] === "string"
+      ? env["project"]
+      : typeof context.resource.attributes?.["project"] === "string"
+        ? (context.resource.attributes["project"] as string)
+        : undefined;
+
+  const branch =
+    typeof env["branch"] === "string"
+      ? env["branch"]
+      : typeof context.resource.attributes?.["branch"] === "string"
+        ? (context.resource.attributes["branch"] as string)
+        : undefined;
+
+  const tool =
+    typeof env["tool"] === "string"
+      ? env["tool"]
+      : typeof context.resource.attributes?.["tool"] === "string"
+        ? (context.resource.attributes["tool"] as string)
+        : undefined;
+
+  const timestampRaw = env["timestamp"];
+  const timestamp =
+    typeof timestampRaw === "string" || timestampRaw instanceof Date
+      ? new Date(timestampRaw)
+      : null;
+
+  const validTimestamp = timestamp && !Number.isNaN(timestamp.valueOf()) ? timestamp : undefined;
+  const day = validTimestamp ? DAY_LABELS[validTimestamp.getUTCDay()] : undefined;
+  const time = validTimestamp
+    ? `${pad2(validTimestamp.getUTCHours())}:${pad2(validTimestamp.getUTCMinutes())}`
+    : undefined;
+  const timeMinutes = validTimestamp
+    ? validTimestamp.getUTCHours() * 60 + validTimestamp.getUTCMinutes()
+    : undefined;
+
+  return {
+    ...(role !== undefined ? { role } : {}),
+    ...(roles.length > 0 ? { roles } : {}),
+    ...(project !== undefined ? { project } : {}),
+    ...(branch !== undefined ? { branch } : {}),
+    ...(tool !== undefined ? { tool } : {}),
+    ...(day !== undefined ? { day } : {}),
+    ...(time !== undefined ? { time } : {}),
+    ...(timeMinutes !== undefined ? { timeMinutes } : {}),
+  };
+}
+
+export function conditionsMatch(
+  conditions: PolicyCondition[],
+  context: EvaluationContext,
+): boolean {
+  const dimensions = deriveConditionalDimensions(context);
+  return conditions.every((condition) => evaluateCondition(condition, context, dimensions));
+}

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -2,6 +2,8 @@
  * Policy module exports.
  */
 
+export type { ConditionalDimensions } from "./condition-evaluator.js";
+export { conditionsMatch, deriveConditionalDimensions } from "./condition-evaluator.js";
 export type {
   Actor,
   EvaluationContext,

--- a/packages/core/src/policy/policy-evaluator.ts
+++ b/packages/core/src/policy/policy-evaluator.ts
@@ -22,195 +22,97 @@
  * policies will always produce the same result.
  */
 
+import { conditionsMatch } from "./condition-evaluator.js";
 import type { EvaluationContext, PolicyScope } from "./evaluation-context.js";
 
-/**
- * The effect of a policy rule.
- * - 'allow': Grants access if matched
- * - 'deny': Denies access if matched (takes priority over allow)
- */
 export type PolicyEffect = "allow" | "deny";
-
-/**
- * The default effect when no policies match.
- * - 'deny': Fail-closed (secure by default, recommended)
- * - 'allow': Fail-open (permissive, use with caution)
- */
 export type DefaultEffect = "deny" | "allow";
 
-/**
- * Policy condition for matching against context.
- */
 export interface PolicyCondition {
-  /** Field path in the context to check (e.g., "actor.type", "resource.attributes.owner") */
   field: string;
-  /** Operator for comparison */
-  operator: "eq" | "neq" | "in" | "nin" | "contains" | "exists";
-  /** Value to compare against */
+  operator:
+    | "eq"
+    | "neq"
+    | "in"
+    | "nin"
+    | "contains"
+    | "exists"
+    | "regex"
+    | "gt"
+    | "gte"
+    | "lt"
+    | "lte";
   value: unknown;
 }
 
-/**
- * A policy rule that defines permissions.
- */
 export interface Policy {
-  /** Unique identifier for this policy */
   id: string;
-  /** Human-readable name for the policy */
   name: string;
-  /** Optional description */
   description?: string;
-  /** The scope this policy applies at */
   scope: PolicyScope;
-  /** The scope identifier (e.g., org ID) */
   scopeId: string;
-  /** The effect when this policy matches */
   effect: PolicyEffect;
-  /** Actions this policy applies to (wildcards supported) */
   actions: string[];
-  /** Resource types this policy applies to (wildcards supported) */
   resourceTypes: string[];
-  /** Optional conditions for fine-grained matching */
   conditions?: PolicyCondition[];
-  /** Priority within same scope (higher = evaluated first) */
   priority?: number;
-  /** Whether this policy is enabled */
   enabled?: boolean;
 }
 
-/**
- * Details about why a decision was made.
- */
 export interface EvaluationReason {
-  /** The policy that determined the result (if any) */
   matchedPolicyId?: string;
-  /** The matched policy's effect */
   matchedEffect?: PolicyEffect;
-  /** The scope of the matched policy */
   matchedScope?: PolicyScope;
-  /** Number of deny policies that matched */
   denyCount: number;
-  /** Number of allow policies that matched */
   allowCount: number;
-  /** Whether the result came from the default effect */
   usedDefault: boolean;
-  /** All matching policy IDs (for debugging) */
   allMatchedPolicyIds: string[];
 }
 
-/**
- * Result of policy evaluation.
- */
 export interface EvaluationResult {
-  /** Whether access is allowed */
   allowed: boolean;
-  /** The effect (allow/deny) */
   effect: PolicyEffect;
-  /** Details about why this decision was made */
   reason: EvaluationReason;
 }
 
-/**
- * Configuration for the policy evaluator.
- */
 export interface PolicyEvaluatorConfig {
-  /**
-   * Default effect when no policies match.
-   * @default 'deny' (fail-closed)
-   */
   defaultEffect: DefaultEffect;
 }
 
-/**
- * Scope priority order (higher index = higher priority).
- * org > team > project > user
- */
 const SCOPE_PRIORITY: readonly PolicyScope[] = ["user", "project", "team", "org"] as const;
 
-/**
- * Get the priority value for a scope.
- * Higher value = higher priority (takes precedence).
- */
 function getScopePriority(scope: PolicyScope): number {
   const index = SCOPE_PRIORITY.indexOf(scope);
   return index === -1 ? -1 : index;
 }
 
-/**
- * PolicyEvaluator evaluates permission policies against an evaluation context.
- *
- * @example
- * ```ts
- * const evaluator = new PolicyEvaluator({ defaultEffect: 'deny' });
- *
- * const result = evaluator.evaluate(context, policies);
- * if (result.allowed) {
- *   // Access granted
- * } else {
- *   // Access denied: result.reason.matchedPolicyId
- * }
- * ```
- */
 export class PolicyEvaluator {
   private readonly config: PolicyEvaluatorConfig;
 
-  /**
-   * Create a new PolicyEvaluator.
-   *
-   * @param config - Evaluator configuration
-   */
   constructor(config: Partial<PolicyEvaluatorConfig> = {}) {
     this.config = {
       defaultEffect: config.defaultEffect ?? "deny",
     };
   }
 
-  /**
-   * Get the current default effect.
-   */
   get defaultEffect(): DefaultEffect {
     return this.config.defaultEffect;
   }
 
-  /**
-   * Evaluate policies against a context.
-   *
-   * Evaluation order:
-   * 1. Filter to enabled policies that match the context
-   * 2. Sort by scope priority (org > team > project > user)
-   * 3. Within same scope, sort by priority (higher first)
-   * 4. Explicit denies take precedence over allows
-   * 5. If no policies match, use the default effect
-   *
-   * @param context - The evaluation context
-   * @param policies - The policies to evaluate
-   * @returns The evaluation result
-   */
   evaluate(context: EvaluationContext, policies: Policy[]): EvaluationResult {
-    // Filter to enabled policies only
     const enabledPolicies = policies.filter((p) => p.enabled !== false);
-
-    // Find all matching policies
     const matchingPolicies = enabledPolicies.filter((p) => this.policyMatches(p, context));
 
-    // If no policies match, use the default
     if (matchingPolicies.length === 0) {
       return this.createDefaultResult();
     }
 
-    // Sort by scope priority (highest first), then by policy priority
     const sortedPolicies = this.sortPolicies(matchingPolicies);
-
-    // Collect all matching policy IDs for debugging
     const allMatchedPolicyIds = sortedPolicies.map((p) => p.id);
-
-    // Count denies and allows
     const denyPolicies = sortedPolicies.filter((p) => p.effect === "deny");
     const allowPolicies = sortedPolicies.filter((p) => p.effect === "allow");
 
-    // Explicit deny takes precedence
     if (denyPolicies.length > 0) {
-      // Find the highest-priority deny
       const [topDeny] = denyPolicies;
       if (topDeny) {
         return {
@@ -229,7 +131,6 @@ export class PolicyEvaluator {
       }
     }
 
-    // No denies, check for allows
     if (allowPolicies.length > 0) {
       const [topAllow] = allowPolicies;
       if (topAllow) {
@@ -249,15 +150,10 @@ export class PolicyEvaluator {
       }
     }
 
-    // Should not reach here, but fall back to default
     return this.createDefaultResult();
   }
 
-  /**
-   * Check if a policy matches the given context.
-   */
   private policyMatches(policy: Policy, context: EvaluationContext): boolean {
-    // Check if the policy's scope is in the context's scope chain
     const scopeInChain = context.scopeChain.some(
       (entry) => entry.scope === policy.scope && entry.id === policy.scopeId,
     );
@@ -265,19 +161,16 @@ export class PolicyEvaluator {
       return false;
     }
 
-    // Check if the action matches
     if (!this.matchesPattern(context.action, policy.actions)) {
       return false;
     }
 
-    // Check if the resource type matches
     if (!this.matchesPattern(context.resource.type, policy.resourceTypes)) {
       return false;
     }
 
-    // Check conditions if present
     if (policy.conditions && policy.conditions.length > 0) {
-      if (!this.conditionsMatch(policy.conditions, context)) {
+      if (!conditionsMatch(policy.conditions, context)) {
         return false;
       }
     }
@@ -285,10 +178,6 @@ export class PolicyEvaluator {
     return true;
   }
 
-  /**
-   * Check if a value matches any pattern in the list.
-   * Supports wildcards (*).
-   */
   private matchesPattern(value: string, patterns: string[]): boolean {
     return patterns.some((pattern) => {
       if (pattern === "*") return true;
@@ -304,79 +193,19 @@ export class PolicyEvaluator {
     });
   }
 
-  /**
-   * Check if all conditions match the context.
-   */
-  private conditionsMatch(conditions: PolicyCondition[], context: EvaluationContext): boolean {
-    return conditions.every((condition) => this.conditionMatches(condition, context));
-  }
-
-  /**
-   * Check if a single condition matches.
-   */
-  private conditionMatches(condition: PolicyCondition, context: EvaluationContext): boolean {
-    const fieldValue = this.getFieldValue(condition.field, context);
-
-    switch (condition.operator) {
-      case "eq":
-        return fieldValue === condition.value;
-      case "neq":
-        return fieldValue !== condition.value;
-      case "in":
-        return Array.isArray(condition.value) && condition.value.includes(fieldValue);
-      case "nin":
-        return Array.isArray(condition.value) && !condition.value.includes(fieldValue);
-      case "contains":
-        return Array.isArray(fieldValue) && fieldValue.includes(condition.value);
-      case "exists":
-        return condition.value ? fieldValue !== undefined : fieldValue === undefined;
-      default:
-        return false;
-    }
-  }
-
-  /**
-   * Get a nested field value from the context.
-   */
-  private getFieldValue(field: string, context: EvaluationContext): unknown {
-    const parts = field.split(".");
-    let value: unknown = context;
-
-    for (const part of parts) {
-      if (value === null || value === undefined) {
-        return undefined;
-      }
-      if (typeof value === "object") {
-        value = (value as Record<string, unknown>)[part];
-      } else {
-        return undefined;
-      }
-    }
-
-    return value;
-  }
-
-  /**
-   * Sort policies by scope priority (highest first), then by policy priority.
-   */
   private sortPolicies(policies: Policy[]): Policy[] {
     return [...policies].sort((a, b) => {
-      // First, compare by scope priority (higher scope = higher priority)
       const scopePriorityDiff = getScopePriority(b.scope) - getScopePriority(a.scope);
       if (scopePriorityDiff !== 0) {
         return scopePriorityDiff;
       }
 
-      // Then, compare by policy priority (higher = first)
       const aPriority = a.priority ?? 0;
       const bPriority = b.priority ?? 0;
       return bPriority - aPriority;
     });
   }
 
-  /**
-   * Create a result using the default effect.
-   */
   private createDefaultResult(): EvaluationResult {
     const allowed = this.config.defaultEffect === "allow";
     return {
@@ -392,17 +221,10 @@ export class PolicyEvaluator {
   }
 }
 
-/**
- * Create a PolicyEvaluator with fail-closed default (recommended).
- */
 export function createFailClosedEvaluator(): PolicyEvaluator {
   return new PolicyEvaluator({ defaultEffect: "deny" });
 }
 
-/**
- * Create a PolicyEvaluator with fail-open default.
- * Use with caution - explicitly allowing by default is less secure.
- */
 export function createFailOpenEvaluator(): PolicyEvaluator {
   return new PolicyEvaluator({ defaultEffect: "allow" });
 }

--- a/packages/core/src/policy/policy-matcher.ts
+++ b/packages/core/src/policy/policy-matcher.ts
@@ -64,6 +64,8 @@ const evaluateCondition = (
         : typeof fieldValue === "string" && typeof expected === "string"
           ? fieldValue.includes(expected)
           : false;
+    case "exists":
+      return expected ? fieldValue !== undefined : fieldValue === undefined;
     case "regex":
       return typeof fieldValue === "string" && typeof expected === "string"
         ? new RegExp(expected).test(fieldValue)

--- a/packages/core/src/policy/policy-schema.ts
+++ b/packages/core/src/policy/policy-schema.ts
@@ -8,7 +8,19 @@ export type PolicyScope = z.infer<typeof PolicyScopeSchema>;
 
 export const PolicyConditionSchema = z.object({
   field: z.string().min(1),
-  operator: z.enum(["eq", "neq", "in", "nin", "contains", "regex", "gt", "gte", "lt", "lte"]),
+  operator: z.enum([
+    "eq",
+    "neq",
+    "in",
+    "nin",
+    "contains",
+    "exists",
+    "regex",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+  ]),
   value: z.union([
     z.string(),
     z.number(),


### PR DESCRIPTION
## Summary
- add a dedicated conditional evaluator for policy conditions with deterministic derived dimensions
- support conditional dimensions for role, project, branch, tool, and time/day (via `day`, `time`, `timeMinutes`, and `timeWindow`)
- wire conditional evaluation into `PolicyEvaluator` while preserving PERM-004 precedence semantics
- align condition operators across evaluator/schema/matcher (including `exists`, `regex`, numeric comparisons)
- export new conditional helpers/types through policy/core indexes
- add policy evaluator tests for each dimension plus combined-condition deny/allow precedence scenario

## Verification
- `pnpm test`
- `pnpm build`

Closes #60
