### PR TITLE
feat(core): PERM-009 pre/post action hooks with veto support

### DIFF
--- a/packages/core/src/__tests__/policy/action-hooks.test.ts
+++ b/packages/core/src/__tests__/policy/action-hooks.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryAuditStorage } from "../../audit-storage.js";
+import {
+  type ActionHookExecutionError,
+  executeActionWithHooks,
+  PreActionVetoError,
+} from "../../policy/action-hooks.js";
+import { createEvaluationContext } from "../../policy/evaluation-context.js";
+
+const evaluation = createEvaluationContext(
+  { id: "user-1", type: "user" },
+  "execute",
+  { type: "tool-call", id: "shell" },
+  [{ scope: "org", id: "org-1" }],
+);
+
+const context = {
+  evaluation,
+  correlationId: "corr-hooks-1",
+};
+
+describe("executeActionWithHooks", () => {
+  it("runs allow path in deterministic order and returns action result", async () => {
+    const calls: string[] = [];
+
+    const result = await executeActionWithHooks({
+      context,
+      preHooks: [
+        {
+          id: "z-last",
+          run: () => {
+            calls.push("pre:z-last");
+          },
+        },
+        {
+          id: "a-first",
+          run: () => {
+            calls.push("pre:a-first");
+          },
+        },
+      ],
+      postHooks: [
+        {
+          id: "post-b",
+          order: 5,
+          run: () => {
+            calls.push("post:post-b");
+          },
+        },
+        {
+          id: "post-a",
+          order: 1,
+          run: () => {
+            calls.push("post:post-a");
+          },
+        },
+      ],
+      execute: () => {
+        calls.push("action");
+        return "ok";
+      },
+    });
+
+    expect(result).toBe("ok");
+    expect(calls).toEqual(["pre:a-first", "pre:z-last", "action", "post:post-a", "post:post-b"]);
+  });
+
+  it("blocks execution when a pre-hook vetoes", async () => {
+    let actionCalled = false;
+
+    await expect(
+      executeActionWithHooks({
+        context,
+        preHooks: [
+          { id: "risk-gate", run: () => ({ allow: false, reason: "manual approval required" }) },
+        ],
+        execute: () => {
+          actionCalled = true;
+          return "nope";
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "PreActionVetoError",
+      hookId: "risk-gate",
+      reason: "manual approval required",
+    } satisfies Partial<PreActionVetoError>);
+
+    expect(actionCalled).toBe(false);
+  });
+
+  it("wraps hook failures with phase-aware error", async () => {
+    await expect(
+      executeActionWithHooks({
+        context,
+        preHooks: [
+          {
+            id: "pre-crash",
+            run: () => {
+              throw new Error("boom");
+            },
+          },
+        ],
+        execute: () => "never",
+      }),
+    ).rejects.toMatchObject({
+      name: "ActionHookExecutionError",
+      phase: "pre",
+      hookId: "pre-crash",
+    } satisfies Partial<ActionHookExecutionError>);
+  });
+
+  it("runs post-hooks on action failure and passes failure outcome", async () => {
+    const outcomes: string[] = [];
+
+    await expect(
+      executeActionWithHooks({
+        context,
+        postHooks: [
+          {
+            id: "post-observe",
+            run: (hookContext) => {
+              outcomes.push(hookContext.outcome);
+              outcomes.push(String((hookContext.error as Error | undefined)?.message));
+            },
+          },
+        ],
+        execute: () => {
+          throw new Error("action-failed");
+        },
+      }),
+    ).rejects.toThrow("action-failed");
+
+    expect(outcomes).toEqual(["failure", "action-failed"]);
+  });
+
+  it("emits audit events for evaluation, veto, and failures", async () => {
+    const audit = new InMemoryAuditStorage();
+    await audit.init();
+
+    await expect(
+      executeActionWithHooks({
+        context,
+        auditStorage: audit,
+        preHooks: [
+          { id: "pre-ok", run: () => ({ allow: true }) },
+          { id: "pre-veto", run: () => ({ allow: false, reason: "blocked" }) },
+        ],
+        execute: () => "never",
+      }),
+    ).rejects.toBeInstanceOf(PreActionVetoError);
+
+    await expect(
+      executeActionWithHooks({
+        context,
+        auditStorage: audit,
+        postHooks: [
+          {
+            id: "post-fail",
+            run: () => {
+              throw new Error("post-boom");
+            },
+          },
+        ],
+        execute: () => "ok",
+      }),
+    ).rejects.toMatchObject({ phase: "post", hookId: "post-fail" });
+
+    const page = await audit.query({ category: "access" }, 50, 0);
+    const actions = page.entries.map((entry) => entry.action);
+
+    expect(actions).toContain("hook.pre.evaluate");
+    expect(actions).toContain("hook.pre.veto");
+    expect(actions).toContain("hook.post.evaluate");
+    expect(actions).toContain("hook.post.failure");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -215,6 +215,9 @@ export {
 export type { FieldIssue } from "./parse.js";
 export { ParseError, parseCanonical, parseCanonicalString } from "./parse.js";
 export type {
+  ActionHookContext,
+  ActionHookDefinition,
+  ActionHookPhase,
   Actor,
   ApprovalDecisionStatus,
   ApprovalEnforcementStatus,
@@ -238,6 +241,9 @@ export type {
   EvaluationContext,
   EvaluationReason,
   EvaluationResult,
+  ExecuteActionWithHooksOptions,
+  HookAllowResult,
+  HookVetoResult,
   KillSwitchActivationInput,
   KillSwitchDeactivationInput,
   KillSwitchEnforcementInput,
@@ -259,11 +265,16 @@ export type {
   PolicyRiskLevel,
   PolicyScope,
   PolicyValidationResult,
+  PostActionHook,
+  PostActionHookContext,
+  PreActionHook,
+  PreActionHookResult,
   Resource,
   RolePolicyOptions,
   ScopeChainEntry,
 } from "./policy/index.js";
 export {
+  ActionHookExecutionError,
   ApprovalGateService,
   BUILT_IN_ROLES,
   BuiltInRoleSchema,
@@ -280,6 +291,7 @@ export {
   EmergencyKillSwitch,
   evaluatePolicyWithApprovalGate,
   evaluatePolicyWithAudit,
+  executeActionWithHooks,
   KillSwitchBlockedError,
   MatchedRuleSchema,
   matchesGlob,
@@ -294,6 +306,7 @@ export {
   PolicyRiskLevelSchema,
   PolicyRuleSchema,
   PolicyScopeSchema,
+  PreActionVetoError,
   permissionEvaluation,
   resolveBuiltInRoles,
   resolveIdentityRoles,

--- a/packages/core/src/policy/action-hooks.ts
+++ b/packages/core/src/policy/action-hooks.ts
@@ -1,0 +1,230 @@
+import type { AuditStorage } from "../audit-storage.js";
+import type { EvaluationContext } from "./evaluation-context.js";
+
+export type ActionHookPhase = "pre" | "post";
+
+export interface ActionHookContext {
+  evaluation: EvaluationContext;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HookVetoResult {
+  allow: false;
+  reason: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface HookAllowResult {
+  allow: true;
+  metadata?: Record<string, unknown>;
+}
+
+export type PreActionHookResult = HookAllowResult | HookVetoResult | void;
+
+export interface ActionHookDefinition {
+  id: string;
+  order?: number;
+}
+
+export interface PreActionHook extends ActionHookDefinition {
+  run(context: ActionHookContext): Promise<PreActionHookResult> | PreActionHookResult;
+}
+
+export interface PostActionHookContext extends ActionHookContext {
+  outcome: "success" | "failure";
+  result?: unknown;
+  error?: unknown;
+}
+
+export interface PostActionHook extends ActionHookDefinition {
+  run(context: PostActionHookContext): Promise<void> | void;
+}
+
+export interface ExecuteActionWithHooksOptions<T> {
+  context: ActionHookContext;
+  preHooks?: PreActionHook[];
+  postHooks?: PostActionHook[];
+  execute: () => Promise<T> | T;
+  auditStorage?: AuditStorage;
+}
+
+export class PreActionVetoError extends Error {
+  readonly code = "PRE_ACTION_VETO";
+
+  constructor(
+    public readonly hookId: string,
+    public readonly reason: string,
+  ) {
+    super(`Pre-action hook vetoed execution (${hookId}): ${reason}`);
+    this.name = "PreActionVetoError";
+  }
+}
+
+export class ActionHookExecutionError extends Error {
+  readonly code = "ACTION_HOOK_FAILURE";
+
+  constructor(
+    public readonly phase: ActionHookPhase,
+    public readonly hookId: string,
+    cause: unknown,
+  ) {
+    super(`Action ${phase}-hook failed (${hookId})`);
+    this.name = "ActionHookExecutionError";
+    this.cause = cause;
+  }
+}
+
+export async function executeActionWithHooks<T>(
+  options: ExecuteActionWithHooksOptions<T>,
+): Promise<T> {
+  const preHooks = sortHooks(options.preHooks ?? []);
+  const postHooks = sortHooks(options.postHooks ?? []);
+
+  for (const hook of preHooks) {
+    await auditHook("pre", "hook.pre.evaluate", hook.id, options);
+
+    try {
+      const decision = await hook.run(options.context);
+      if (decision && decision.allow === false) {
+        await auditHook("pre", "hook.pre.veto", hook.id, options, {
+          reason: decision.reason,
+          ...(decision.metadata ? { metadata: decision.metadata } : {}),
+        });
+        throw new PreActionVetoError(hook.id, decision.reason);
+      }
+    } catch (error) {
+      if (error instanceof PreActionVetoError) {
+        throw error;
+      }
+
+      await auditHook("pre", "hook.pre.failure", hook.id, options, {
+        error: toErrorMetadata(error),
+      });
+      throw new ActionHookExecutionError("pre", hook.id, error);
+    }
+  }
+
+  let result: T;
+  try {
+    result = await options.execute();
+  } catch (error) {
+    await runPostHooks(postHooks, {
+      ...options,
+      postContext: {
+        ...options.context,
+        outcome: "failure",
+        error,
+      },
+    });
+    throw error;
+  }
+
+  await runPostHooks(postHooks, {
+    ...options,
+    postContext: {
+      ...options.context,
+      outcome: "success",
+      result,
+    },
+  });
+
+  return result;
+}
+
+async function runPostHooks(
+  hooks: PostActionHook[],
+  input: {
+    context: ActionHookContext;
+    postContext: PostActionHookContext;
+    auditStorage?: AuditStorage;
+  },
+): Promise<void> {
+  for (const hook of hooks) {
+    await auditHook("post", "hook.post.evaluate", hook.id, {
+      context: input.context,
+      ...(input.auditStorage ? { auditStorage: input.auditStorage } : {}),
+    });
+
+    try {
+      await hook.run(input.postContext);
+    } catch (error) {
+      await auditHook(
+        "post",
+        "hook.post.failure",
+        hook.id,
+        {
+          context: input.context,
+          ...(input.auditStorage ? { auditStorage: input.auditStorage } : {}),
+        },
+        {
+          error: toErrorMetadata(error),
+        },
+      );
+
+      throw new ActionHookExecutionError("post", hook.id, error);
+    }
+  }
+}
+
+function sortHooks<T extends ActionHookDefinition>(hooks: T[]): T[] {
+  return [...hooks].sort((a, b) => {
+    const orderDelta = (a.order ?? 0) - (b.order ?? 0);
+    if (orderDelta !== 0) {
+      return orderDelta;
+    }
+
+    return a.id.localeCompare(b.id);
+  });
+}
+
+async function auditHook(
+  phase: ActionHookPhase,
+  action: string,
+  hookId: string,
+  input: {
+    context: ActionHookContext;
+    auditStorage?: AuditStorage;
+  },
+  details?: {
+    reason?: string;
+    metadata?: Record<string, unknown>;
+    error?: Record<string, unknown>;
+  },
+): Promise<void> {
+  if (!input.auditStorage) {
+    return;
+  }
+
+  await input.auditStorage.append({
+    category: "access",
+    action,
+    actor: input.context.evaluation.actor.id,
+    targetId: input.context.evaluation.resource.id ?? input.context.evaluation.resource.type,
+    targetType: "hook",
+    severity: action.includes("failure") || action.includes("veto") ? "warning" : "info",
+    ...(details?.reason ? { reason: details.reason } : {}),
+    ...(input.context.correlationId ? { correlationId: input.context.correlationId } : {}),
+    metadata: {
+      hookId,
+      hookPhase: phase,
+      permissionAction: input.context.evaluation.action,
+      resourceType: input.context.evaluation.resource.type,
+      ...(details?.metadata ? { hookMetadata: details.metadata } : {}),
+      ...(details?.error ? { error: details.error } : {}),
+    },
+  });
+}
+
+function toErrorMetadata(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+
+  return {
+    message: String(error),
+  };
+}

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -3,6 +3,23 @@
  */
 
 export type {
+  ActionHookContext,
+  ActionHookDefinition,
+  ActionHookPhase,
+  ExecuteActionWithHooksOptions,
+  HookAllowResult,
+  HookVetoResult,
+  PostActionHook,
+  PostActionHookContext,
+  PreActionHook,
+  PreActionHookResult,
+} from "./action-hooks.js";
+export {
+  ActionHookExecutionError,
+  executeActionWithHooks,
+  PreActionVetoError,
+} from "./action-hooks.js";
+export type {
   ApprovalDecisionStatus,
   ApprovalEnforcementStatus,
   ApprovalGateConfig,


### PR DESCRIPTION
## Summary\n- add a policy hook framework with deterministic ordering for pre-action and post-action hooks\n- support pre-action veto/block decisions with explicit reasons\n- add integration helper to run pre-hooks, execute action callback, then run post-hooks\n- add explicit hook errors for vetoes and hook execution failures\n- emit access audit events for hook evaluation, veto, and failure paths\n- export new hook types and helpers through policy and core indexes\n- add tests for allow, veto, failure handling, deterministic ordering, and post-hook behavior\n\n## Validation\n- pnpm build\n- pnpm test:run\n\nCloses #62