### PR TITLE
feat(core): support policy inheritance and explicit overrides across scopes

### DIFF
--- a/packages/core/src/__tests__/policy/policy-evaluator.test.ts
+++ b/packages/core/src/__tests__/policy/policy-evaluator.test.ts
@@ -759,6 +759,142 @@ describe("PolicyEvaluator", () => {
     });
   });
 
+  describe("PERM-010 inheritance + override semantics", () => {
+    it("inherits higher-scope policies by default", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("read");
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "org-allow-read",
+          effect: "allow",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["read"],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("org-allow-read");
+    });
+
+    it("does not inherit policy when inherit=false and scope is not active scope", () => {
+      const evaluator = new PolicyEvaluator({ defaultEffect: "deny" });
+      const context = createContext("read");
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "org-local-only",
+          effect: "allow",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["read"],
+          inherit: false,
+        }),
+      ]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason.usedDefault).toBe(true);
+      expect(result.reason.allMatchedPolicyIds).toEqual([]);
+    });
+
+    it("allows lower-scope explicit override to cut off inherited higher scopes", () => {
+      const evaluator = new PolicyEvaluator({ defaultEffect: "deny" });
+      const context = createContext("delete");
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "org-deny-delete",
+          effect: "deny",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["delete"],
+        }),
+        createPolicy({
+          id: "project-override-allow-delete",
+          effect: "allow",
+          scope: "project",
+          scopeId: "proj-1",
+          actions: ["delete"],
+          override: true,
+        }),
+      ]);
+
+      expect(result.allowed).toBe(true);
+      expect(result.reason.matchedPolicyId).toBe("project-override-allow-delete");
+      expect(result.reason.allMatchedPolicyIds).toEqual(["project-override-allow-delete"]);
+    });
+
+    it("preserves deny-over-allow precedence after override resolution", () => {
+      const evaluator = new PolicyEvaluator({ defaultEffect: "deny" });
+      const context = createContext("execute", "tool-call");
+
+      const result = evaluator.evaluate(context, [
+        createPolicy({
+          id: "org-deny-exec",
+          effect: "deny",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["execute"],
+          resourceTypes: ["tool-call"],
+        }),
+        createPolicy({
+          id: "project-override-allow-exec",
+          effect: "allow",
+          scope: "project",
+          scopeId: "proj-1",
+          actions: ["execute"],
+          resourceTypes: ["tool-call"],
+          override: true,
+        }),
+        createPolicy({
+          id: "project-deny-exec",
+          effect: "deny",
+          scope: "project",
+          scopeId: "proj-1",
+          actions: ["execute"],
+          resourceTypes: ["tool-call"],
+        }),
+      ]);
+
+      expect(result.allowed).toBe(false);
+      expect(result.effect).toBe("deny");
+      expect(result.reason.matchedPolicyId).toBe("project-deny-exec");
+      expect(result.reason.denyCount).toBe(1);
+      expect(result.reason.allowCount).toBe(1);
+    });
+
+    it("resolves same-scope/same-priority ties deterministically by policy id", () => {
+      const evaluator = new PolicyEvaluator();
+      const context = createContext("read");
+
+      const policies: Policy[] = [
+        createPolicy({
+          id: "z-policy",
+          effect: "allow",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["read"],
+          priority: 0,
+        }),
+        createPolicy({
+          id: "a-policy",
+          effect: "allow",
+          scope: "org",
+          scopeId: "org-1",
+          actions: ["read"],
+          priority: 0,
+        }),
+      ];
+
+      const result1 = evaluator.evaluate(context, policies);
+      const result2 = evaluator.evaluate(context, [...policies].reverse());
+
+      expect(result1.reason.matchedPolicyId).toBe("a-policy");
+      expect(result2.reason.matchedPolicyId).toBe("a-policy");
+    });
+  });
+
   describe("evaluation consistency and determinism", () => {
     it("produces same result for same input", () => {
       const evaluator = new PolicyEvaluator();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,6 +310,7 @@ export {
   permissionEvaluation,
   resolveBuiltInRoles,
   resolveIdentityRoles,
+  resolveInheritedPolicies,
   validatePolicyDocument,
   validatePolicyJson,
   validatePolicyYaml,

--- a/packages/core/src/policy/index.ts
+++ b/packages/core/src/policy/index.ts
@@ -93,6 +93,7 @@ export {
   createFailClosedEvaluator,
   createFailOpenEvaluator,
   PolicyEvaluator,
+  resolveInheritedPolicies,
 } from "./policy-evaluator.js";
 export type { PolicyMatchContext } from "./policy-matcher.js";
 export { matchesGlob, matchesRule } from "./policy-matcher.js";

--- a/packages/core/src/policy/policy-evaluator.ts
+++ b/packages/core/src/policy/policy-evaluator.ts
@@ -14,7 +14,13 @@
  *    - Higher scopes take precedence over lower scopes
  *    - An org-level deny overrides a project-level allow
  *
- * 3. **Default Behavior**: Configurable per organization
+ * 3. **Inheritance/Override** (PERM-010)
+ *    - Policies are inherited down the scope chain by default
+ *    - `inherit: false` restricts a policy to its own scope context only
+ *    - `override: true` at a lower scope cuts off inherited higher-scope
+ *      policies for the current evaluation context
+ *
+ * 4. **Default Behavior**: Configurable per organization
  *    - fail-closed (deny): Default for new organizations
  *    - fail-open (allow): Must be explicitly configured
  *
@@ -59,6 +65,17 @@ export interface Policy {
   conditions?: PolicyCondition[];
   priority?: number;
   enabled?: boolean;
+  /**
+   * Whether this policy should be inherited by lower scopes.
+   * Defaults to true.
+   */
+  inherit?: boolean;
+  /**
+   * Whether this policy explicitly overrides inherited policies from
+   * higher scopes for the current evaluation context.
+   * Defaults to false.
+   */
+  override?: boolean;
   /** Marks an allowed action as requiring human approval before execution. */
   requiresApproval?: boolean;
   /** High-risk actions are treated as approval-gated by approval integrations. */
@@ -94,6 +111,42 @@ function getScopePriority(scope: PolicyScope): number {
   return index === -1 ? -1 : index;
 }
 
+/**
+ * Resolve the effective matching policy set after applying inheritance
+ * and explicit override behavior.
+ */
+export function resolveInheritedPolicies(
+  context: EvaluationContext,
+  matchingPolicies: Policy[],
+): Policy[] {
+  const activeScope = context.scopeChain[0];
+
+  const inheritablePolicies = matchingPolicies.filter((policy) => {
+    if (policy.inherit !== false) {
+      return true;
+    }
+
+    if (!activeScope) {
+      return false;
+    }
+
+    return policy.scope === activeScope.scope && policy.scopeId === activeScope.id;
+  });
+
+  const overridePolicies = inheritablePolicies.filter((policy) => policy.override === true);
+  if (overridePolicies.length === 0) {
+    return inheritablePolicies;
+  }
+
+  const strongestOverridePriority = Math.min(
+    ...overridePolicies.map((policy) => getScopePriority(policy.scope)),
+  );
+
+  return inheritablePolicies.filter(
+    (policy) => getScopePriority(policy.scope) <= strongestOverridePriority,
+  );
+}
+
 export class PolicyEvaluator {
   private readonly config: PolicyEvaluatorConfig;
 
@@ -110,12 +163,13 @@ export class PolicyEvaluator {
   evaluate(context: EvaluationContext, policies: Policy[]): EvaluationResult {
     const enabledPolicies = policies.filter((p) => p.enabled !== false);
     const matchingPolicies = enabledPolicies.filter((p) => this.policyMatches(p, context));
+    const resolvedPolicies = resolveInheritedPolicies(context, matchingPolicies);
 
-    if (matchingPolicies.length === 0) {
+    if (resolvedPolicies.length === 0) {
       return this.createDefaultResult();
     }
 
-    const sortedPolicies = this.sortPolicies(matchingPolicies);
+    const sortedPolicies = this.sortPolicies(resolvedPolicies);
     const allMatchedPolicyIds = sortedPolicies.map((p) => p.id);
     const denyPolicies = sortedPolicies.filter((p) => p.effect === "deny");
     const allowPolicies = sortedPolicies.filter((p) => p.effect === "allow");
@@ -210,7 +264,11 @@ export class PolicyEvaluator {
 
       const aPriority = a.priority ?? 0;
       const bPriority = b.priority ?? 0;
-      return bPriority - aPriority;
+      if (bPriority !== aPriority) {
+        return bPriority - aPriority;
+      }
+
+      return a.id.localeCompare(b.id);
     });
   }
 

--- a/packages/core/src/policy/policy-schema.ts
+++ b/packages/core/src/policy/policy-schema.ts
@@ -42,6 +42,8 @@ export const PolicyRuleSchema = z.object({
   scopeId: z.string().min(1),
   conditions: z.array(PolicyConditionSchema).default([]),
   description: z.string().optional(),
+  inherit: z.boolean().optional(),
+  override: z.boolean().optional(),
   requiresApproval: z.boolean().optional(),
   riskLevel: PolicyRiskLevelSchema.optional(),
   approvalTtlMs: z.number().int().positive().optional(),


### PR DESCRIPTION
Implements PERM-010 for policy inheritance/override semantics across scope chains.

## What changed
- Added inheritance resolver (`resolveInheritedPolicies`) in policy evaluator.
- Added explicit policy flags:
  - `inherit?: boolean` (default inherited behavior)
  - `override?: boolean` (cuts off inherited higher-scope policies for current eval context)
- Integrated inheritance resolution into `PolicyEvaluator.evaluate(...)`.
- Preserved deny-over-allow precedence after inheritance/override resolution.
- Added deterministic tie-break for same-scope/same-priority policies (policy `id` lexical order).
- Extended canonical policy schema with `inherit` and `override` optional fields.
- Exported new API from `policy/index.ts` and root `core/index.ts`.
- Added evaluator tests for inheritance chain + override scenarios.

## Validation
- `pnpm run build` ✅
- `pnpm run test:run` ✅ (680 passed, 1 skipped)

Closes #63
