### PR TITLE
docs(readme): update README with agent-agnostic verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,24 @@
 > Write your project instructions once. Sync them everywhere.
 
 LAUP is a middleware layer that solves configuration fragmentation for teams running multiple
-LLM coding agents. Claude Code, Cursor, and Aider each require their own instruction file
-format. LAUP maintains a single canonical instruction file and propagates it to every tool
-automatically.
+LLM coding agents. Different tools require different instruction file formats, and supported
+tools are extended over time through adapters. LAUP maintains a single canonical instruction
+file and propagates it to every configured tool automatically.
 
 ## The Problem
 
-Running three agents means maintaining three instruction files — `CLAUDE.md`, `.cursorrules`,
-`.aider.conf.yml` — that diverge the moment anyone edits one of them. Teams either accept drift
-or manually synchronize files that should be identical.
+Running multiple agents means maintaining multiple instruction files that diverge the moment
+anyone edits one of them. Teams either accept drift or manually synchronize files that should be
+identical.
 
 ## The Solution
 
 ```text
-laup.md  ->  laup sync  ->  CLAUDE.md
-                       ->  .cursorrules
-                       ->  .cursor/rules/laup.mdc
-                       ->  .aider.conf.yml + CONVENTIONS.md
+laup.md  ->  laup sync  ->  CLAUDE.md                  (Claude Code adapter)
+                        ->  .cursorrules               (Cursor adapter)
+                        ->  .cursor/rules/laup.mdc     (Cursor rules adapter)
+                        ->  .aider.conf.yml + CONVENTIONS.md (Aider adapter)
+                        ->  ...additional adapter outputs
 ```
 
 One source of truth. One command to propagate.


### PR DESCRIPTION
## Summary
This PR updates the README introduction to be agent-agnostic and adapter-oriented, so it doesn’t imply LAUP is limited to only three tools.

## Why
The previous wording (“three agents” with Claude/Cursor/Aider called out in the intro) could make users of other tools assume LAUP is not relevant to them. This change clarifies that support is extensible via adapters.

## Changes Made
- Reworded intro text to describe compatibility as adapter-based and growing over time.
- Changed “Running three agents…” to “Running multiple agents…”.
- Kept practical output examples in the solution diagram, but labeled them as adapter examples and added `...additional adapter outputs`.

## Scope
- Docs only (`README.md`)
- No code, CLI behavior, or adapter logic changes

## Validation
- Manually reviewed the updated README section for clarity and consistency.
- No tests required for this documentation-only update.