### PR TITLE
feat(config-hub): CLI + API CRUD across org/project/user scopes (CONF-009)

### DIFF
--- a/packages/config-hub/src/__tests__/api-server.test.ts
+++ b/packages/config-hub/src/__tests__/api-server.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ConfigApiServer, tokenAuthenticator } from "../api-server.js";
+import { ScopeDocumentStore } from "../crud.js";
+
+const DOC = `---
+version: "1.0"
+scope: project
+---
+
+# API
+`;
+
+describe("ConfigApiServer", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    roots.forEach((r) => {
+      rmSync(r, { recursive: true, force: true });
+    });
+  });
+
+  async function setup() {
+    const root = mkdtempSync(join(tmpdir(), "laup-api-"));
+    roots.push(root);
+    const store = new ScopeDocumentStore({
+      projectPath: join(root, "laup.md"),
+      orgPath: join(root, "org.md"),
+      teamsDir: join(root, "teams"),
+    });
+    const server = new ConfigApiServer({ store, authenticate: tokenAuthenticator("token") });
+    const port = await server.listen(0);
+    return { server, base: `http://127.0.0.1:${port}/v1/configs` };
+  }
+
+  it("requires auth", async () => {
+    const { server, base } = await setup();
+    const res = await fetch(`${base}/project`);
+    expect(res.status).toBe(401);
+    await server.close();
+  });
+
+  it("supports CRUD", async () => {
+    const { server, base } = await setup();
+    const headers = { authorization: "Bearer token", "content-type": "application/json" };
+    expect(
+      (
+        await fetch(`${base}/project`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ content: DOC }),
+        })
+      ).status,
+    ).toBe(201);
+    expect((await fetch(`${base}/project`, { headers })).status).toBe(200);
+    expect(
+      (
+        await fetch(`${base}/project`, {
+          method: "PUT",
+          headers,
+          body: JSON.stringify({ content: DOC.replace("# API", "# Updated") }),
+        })
+      ).status,
+    ).toBe(200);
+    expect((await fetch(`${base}/project`, { method: "DELETE", headers })).status).toBe(200);
+    await server.close();
+  });
+
+  it("returns structured validation errors", async () => {
+    const { server, base } = await setup();
+    const res = await fetch(`${base}/org`, {
+      method: "POST",
+      headers: { authorization: "Bearer token", "content-type": "application/json" },
+      body: JSON.stringify({ content: "---\n:bad\n---\n" }),
+    });
+    expect(res.status).toBe(400);
+    const payload = (await res.json()) as { error: { code: string } };
+    expect(payload.error.code).toBe("VALIDATION_ERROR");
+    await server.close();
+  });
+});

--- a/packages/config-hub/src/__tests__/crud.test.ts
+++ b/packages/config-hub/src/__tests__/crud.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ScopeCrudError, ScopeDocumentStore } from "../crud.js";
+
+const DOC = `---
+version: "1.0"
+scope: project
+---
+
+# Test
+`;
+
+describe("ScopeDocumentStore", () => {
+  const roots: string[] = [];
+  afterEach(() => {
+    roots.forEach((r) => {
+      rmSync(r, { recursive: true, force: true });
+    });
+  });
+
+  function makeStore() {
+    const root = mkdtempSync(join(tmpdir(), "laup-crud-"));
+    roots.push(root);
+    return new ScopeDocumentStore({
+      projectPath: join(root, "laup.md"),
+      orgPath: join(root, "org.md"),
+      teamsDir: join(root, "teams"),
+    });
+  }
+
+  it("creates/reads/updates/deletes", () => {
+    const store = makeStore();
+    store.create({ scope: "project" }, DOC);
+    expect(store.read({ scope: "project" }).content).toContain("# Test");
+    store.update({ scope: "project" }, DOC.replace("# Test", "# Updated"));
+    expect(store.read({ scope: "project" }).content).toContain("# Updated");
+    store.delete({ scope: "project" });
+    expect(() => store.read({ scope: "project" })).toThrow(ScopeCrudError);
+  });
+
+  it("validates team scope-id", () => {
+    const store = makeStore();
+    expect(() => store.read({ scope: "team" })).toThrow(ScopeCrudError);
+  });
+
+  it("returns validation errors", () => {
+    const store = makeStore();
+    expect(() => store.create({ scope: "org" }, "---\n:bad\n---\n")).toThrow(ScopeCrudError);
+  });
+});

--- a/packages/config-hub/src/api-server.ts
+++ b/packages/config-hub/src/api-server.ts
@@ -1,0 +1,103 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { URL } from "node:url";
+import { type ConfigScope, ScopeCrudError, type ScopeDocumentStore } from "./crud.js";
+
+export interface AuthIdentity {
+  id: string;
+}
+export type RequestAuthenticator = (req: IncomingMessage) => AuthIdentity | null;
+export interface ConfigApiServerOptions {
+  store: ScopeDocumentStore;
+  authenticate: RequestAuthenticator;
+}
+
+export class ConfigApiServer {
+  private readonly server: Server;
+  constructor(private readonly options: ConfigApiServerOptions) {
+    this.server = createServer((req, res) => void this.handle(req, res));
+  }
+  listen(port = 0): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server.once("error", reject);
+      this.server.listen(port, () => {
+        this.server.off("error", reject);
+        const address = this.server.address();
+        if (!address || typeof address === "string")
+          return reject(new Error("Failed to bind API server"));
+        resolve(address.port);
+      });
+    });
+  }
+  close(): Promise<void> {
+    return new Promise((resolve, reject) => this.server.close((e) => (e ? reject(e) : resolve())));
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (!this.options.authenticate(req))
+      return this.respond(res, 401, {
+        error: { code: "UNAUTHORIZED", message: "Authentication required" },
+      });
+    const route = this.parseRoute(req.url ?? "/");
+    if (!route)
+      return this.respond(res, 404, { error: { code: "NOT_FOUND", message: "Route not found" } });
+    try {
+      if (req.method === "GET") return this.respond(res, 200, this.options.store.read(route));
+      if (req.method === "DELETE") return this.respond(res, 200, this.options.store.delete(route));
+      if (req.method === "POST" || req.method === "PUT") {
+        const body = (await this.readJson(req)) as { content?: unknown };
+        if (typeof body.content !== "string")
+          throw new ScopeCrudError(
+            "INVALID_REQUEST",
+            "Request body must include string field: content",
+            400,
+          );
+        const result =
+          req.method === "POST"
+            ? this.options.store.create(route, body.content)
+            : this.options.store.update(route, body.content);
+        return this.respond(res, req.method === "POST" ? 201 : 200, result);
+      }
+      return this.respond(res, 405, {
+        error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" },
+      });
+    } catch (error) {
+      if (error instanceof ScopeCrudError)
+        return this.respond(res, error.status, {
+          error: { code: error.code, message: error.message, details: error.details ?? null },
+        });
+      if (error instanceof SyntaxError)
+        return this.respond(res, 400, { error: { code: "INVALID_JSON", message: error.message } });
+      return this.respond(res, 500, { error: { code: "INTERNAL_ERROR", message: String(error) } });
+    }
+  }
+
+  private parseRoute(url: string): { scope: ConfigScope; scopeId?: string } | null {
+    const parts = new URL(url, "http://localhost").pathname.split("/").filter(Boolean);
+    if (parts[0] !== "v1" || parts[1] !== "configs") return null;
+    const scope = parts[2] as ConfigScope | undefined;
+    if (scope !== "org" && scope !== "team" && scope !== "project") return null;
+    return { scope, ...(parts[3] ? { scopeId: parts[3] } : {}) };
+  }
+
+  private async readJson(req: IncomingMessage): Promise<unknown> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    if (chunks.length === 0) return {};
+    return JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+  }
+
+  private respond(res: ServerResponse, status: number, payload: unknown): void {
+    res.statusCode = status;
+    res.setHeader("content-type", "application/json; charset=utf-8");
+    res.end(JSON.stringify(payload));
+  }
+}
+
+export function tokenAuthenticator(expectedToken: string): RequestAuthenticator {
+  return (req) => {
+    const auth = req.headers.authorization;
+    if (!auth) return null;
+    const [scheme, token] = auth.split(" ");
+    return scheme === "Bearer" && token === expectedToken ? { id: "api-token" } : null;
+  };
+}

--- a/packages/config-hub/src/crud.ts
+++ b/packages/config-hub/src/crud.ts
@@ -1,0 +1,116 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { type CanonicalInstruction, getDefaultScopePath, parseCanonicalString } from "@laup/core";
+
+export type ConfigScope = "org" | "team" | "project";
+export interface ScopeRef {
+  scope: ConfigScope;
+  scopeId?: string;
+}
+export interface ScopeCrudOptions {
+  projectPath?: string;
+  orgPath?: string;
+  teamsDir?: string;
+}
+export interface ScopeDocument {
+  scope: ConfigScope;
+  scopeId?: string;
+  path: string;
+  content: string;
+  document: CanonicalInstruction;
+}
+export type CrudErrorCode =
+  | "NOT_FOUND"
+  | "ALREADY_EXISTS"
+  | "VALIDATION_ERROR"
+  | "INVALID_SCOPE"
+  | "INVALID_REQUEST";
+
+export class ScopeCrudError extends Error {
+  constructor(
+    public readonly code: CrudErrorCode,
+    message: string,
+    public readonly status: number,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "ScopeCrudError";
+  }
+}
+
+export class ScopeDocumentStore {
+  constructor(private readonly options: ScopeCrudOptions = {}) {}
+
+  create(ref: ScopeRef, content: string): ScopeDocument {
+    const path = this.resolvePath(ref);
+    if (existsSync(path))
+      throw new ScopeCrudError("ALREADY_EXISTS", `Document already exists at ${path}`, 409, {
+        path,
+      });
+    const document = this.parse(content, path);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, "utf-8");
+    return { ...ref, path, content, document };
+  }
+
+  read(ref: ScopeRef): ScopeDocument {
+    const path = this.resolvePath(ref);
+    if (!existsSync(path))
+      throw new ScopeCrudError("NOT_FOUND", `Document not found at ${path}`, 404, { path });
+    const content = readFileSync(path, "utf-8");
+    return { ...ref, path, content, document: this.parse(content, path) };
+  }
+
+  update(ref: ScopeRef, content: string): ScopeDocument {
+    const path = this.resolvePath(ref);
+    if (!existsSync(path))
+      throw new ScopeCrudError("NOT_FOUND", `Document not found at ${path}`, 404, { path });
+    const document = this.parse(content, path);
+    writeFileSync(path, content, "utf-8");
+    return { ...ref, path, content, document };
+  }
+
+  delete(ref: ScopeRef): { scope: ConfigScope; scopeId?: string; path: string } {
+    const path = this.resolvePath(ref);
+    if (!existsSync(path))
+      throw new ScopeCrudError("NOT_FOUND", `Document not found at ${path}`, 404, { path });
+    rmSync(path);
+    return { ...ref, path };
+  }
+
+  private parse(content: string, path: string): CanonicalInstruction {
+    try {
+      return parseCanonicalString(content);
+    } catch (error) {
+      const err = error as { message?: string; issues?: unknown };
+      throw new ScopeCrudError("VALIDATION_ERROR", `Invalid canonical document at ${path}`, 400, {
+        path,
+        issues: err.issues ?? [{ message: err.message ?? String(error) }],
+      });
+    }
+  }
+
+  private resolvePath(ref: ScopeRef): string {
+    switch (ref.scope) {
+      case "org":
+        return resolve(this.options.orgPath ?? getDefaultScopePath("org"));
+      case "team": {
+        if (!ref.scopeId)
+          throw new ScopeCrudError("INVALID_REQUEST", "team scope requires scopeId", 400);
+        return resolve(
+          this.options.teamsDir
+            ? `${this.options.teamsDir}/${ref.scopeId}.md`
+            : getDefaultScopePath("team", ref.scopeId),
+        );
+      }
+      case "project":
+        return resolve(this.options.projectPath ?? getDefaultScopePath("project"));
+      default:
+        throw new ScopeCrudError(
+          "INVALID_SCOPE",
+          `Unsupported scope: ${(ref as ScopeRef).scope}`,
+          400,
+        );
+    }
+  }
+}

--- a/packages/config-hub/src/index.ts
+++ b/packages/config-hub/src/index.ts
@@ -6,10 +6,14 @@ import { parseCanonical, validateCanonical } from "@laup/core";
 import { computeDiff, type DiffResult } from "./diff.js";
 
 export type { ValidationResult };
+export type { AuthIdentity, ConfigApiServerOptions, RequestAuthenticator } from "./api-server.js";
+export { ConfigApiServer, tokenAuthenticator } from "./api-server.js";
 export type { AuditQuery, DocumentAuditRecord, DocumentChangeAction } from "./audit-history.js";
 export { DocumentAuditHistory } from "./audit-history.js";
 export type { MergeChange, MergeResult } from "./auto-merge.js";
 export { autoMergeAdditive } from "./auto-merge.js";
+export type { ConfigScope, ScopeCrudOptions, ScopeDocument, ScopeRef } from "./crud.js";
+export { ScopeCrudError, ScopeDocumentStore } from "./crud.js";
 export type { DiffLine, DiffResult } from "./diff.js";
 export { computeDiff, formatDiff } from "./diff.js";
 export type {


### PR DESCRIPTION
## Summary\n- add filesystem-backed scope document store with CRUD operations\n- add lightweight API server interface to expose CRUD over HTTP-style handlers\n- export new config-hub APIs and add coverage tests\n\nCloses #12