### PR TITLE
feat(core): slash-command skill outputs for all supported tools (SKILL-006)

### DIFF
--- a/packages/core/src/__tests__/skill-renderer.test.ts
+++ b/packages/core/src/__tests__/skill-renderer.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   AiderSkillRenderer,
   ClaudeCodeSkillRenderer,
+  CodexSkillRenderer,
+  CopilotSkillRenderer,
   CursorSkillRenderer,
   getSkillRenderer,
+  OpenCodeSkillRenderer,
   renderSkillToAllTools,
 } from "../skill-renderer.js";
 import type { Skill } from "../skill-schema.js";
@@ -57,11 +60,12 @@ describe("skill-renderer", () => {
       expect(output).toContain("**focus** `selection` (optional)");
       expect(output).toContain("You are a senior code reviewer");
       expect(output).toContain("{{language}}");
+      expect(output).toContain("Prompt for all required parameters when this command is invoked");
     });
 
-    it("generates correct filename", () => {
+    it("generates command-based filename", () => {
       const filename = renderer.getFilename(sampleSkill);
-      expect(filename).toBe("skill-code-review.md");
+      expect(filename).toBe("review.md");
     });
 
     it("handles skill without optional fields", () => {
@@ -93,6 +97,7 @@ describe("skill-renderer", () => {
       expect(output).toContain("# code-review");
       expect(output).toContain("**Trigger:** `/review`");
       expect(output).toContain("`{{language}}`");
+      expect(output).toContain("Prompt for all required parameters when this command is invoked");
     });
 
     it("includes cursor-specific overrides", () => {
@@ -112,9 +117,9 @@ describe("skill-renderer", () => {
       expect(output).toContain("alwaysApply: true");
     });
 
-    it("generates correct filename", () => {
+    it("generates command-based filename", () => {
       const filename = renderer.getFilename(sampleSkill);
-      expect(filename).toBe("code-review.mdc");
+      expect(filename).toBe("review.mdc");
     });
   });
 
@@ -136,9 +141,20 @@ describe("skill-renderer", () => {
     });
   });
 
+  describe("additional markdown renderers", () => {
+    it("generate command-based filenames", () => {
+      expect(new CodexSkillRenderer().getFilename(sampleSkill)).toBe("review.md");
+      expect(new OpenCodeSkillRenderer().getFilename(sampleSkill)).toBe("review.md");
+      expect(new CopilotSkillRenderer().getFilename(sampleSkill)).toBe("review.md");
+    });
+  });
+
   describe("getSkillRenderer", () => {
     it("returns renderer for known tool", () => {
       expect(getSkillRenderer("claude-code")).toBeInstanceOf(ClaudeCodeSkillRenderer);
+      expect(getSkillRenderer("codex")).toBeInstanceOf(CodexSkillRenderer);
+      expect(getSkillRenderer("opencode")).toBeInstanceOf(OpenCodeSkillRenderer);
+      expect(getSkillRenderer("copilot")).toBeInstanceOf(CopilotSkillRenderer);
       expect(getSkillRenderer("cursor")).toBeInstanceOf(CursorSkillRenderer);
       expect(getSkillRenderer("aider")).toBeInstanceOf(AiderSkillRenderer);
     });
@@ -152,8 +168,15 @@ describe("skill-renderer", () => {
     it("renders skill to all tools", () => {
       const results = renderSkillToAllTools(sampleSkill);
 
-      expect(results).toHaveLength(3);
-      expect(results.map((r) => r.toolId).sort()).toEqual(["aider", "claude-code", "cursor"]);
+      expect(results).toHaveLength(6);
+      expect(results.map((r) => r.toolId).sort()).toEqual([
+        "aider",
+        "claude-code",
+        "codex",
+        "copilot",
+        "cursor",
+        "opencode",
+      ]);
 
       for (const result of results) {
         expect(result.filename).toBeTruthy();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -210,24 +210,6 @@ export {
   MemoryJobQueue,
 } from "./job-queue.js";
 export type {
-  MarketplaceApiOptions,
-  MarketplaceApiRequest,
-  MarketplaceApiResponse,
-  MarketplacePage,
-  MarketplaceQuery,
-  MarketplaceSkill,
-  MarketplaceSortBy,
-  MarketplaceSortOrder,
-  MarketplaceWebOptions,
-  SkillMarketplace,
-} from "./marketplace.js";
-export {
-  createMarketplaceApiHandler,
-  InMemorySkillMarketplace,
-  renderMarketplaceHtml,
-  renderMarketplacePage,
-} from "./marketplace.js";
-export type {
   McpPropagationOptions,
   McpPropagationReport,
   McpPropagationTarget,
@@ -523,8 +505,11 @@ export type { SkillRenderer } from "./skill-renderer.js";
 export {
   AiderSkillRenderer,
   ClaudeCodeSkillRenderer,
+  CodexSkillRenderer,
+  CopilotSkillRenderer,
   CursorSkillRenderer,
   getSkillRenderer,
+  OpenCodeSkillRenderer,
   renderSkillToAllTools,
   skillRenderers,
 } from "./skill-renderer.js";

--- a/packages/core/src/skill-renderer.ts
+++ b/packages/core/src/skill-renderer.ts
@@ -28,6 +28,92 @@ function escapeYamlDoubleQuoted(value: string): string {
 }
 
 /**
+ * Convert a slash command (e.g. "/review") into a filesystem-safe base name.
+ * Slash-command-capable tools resolve command names from file names, so this
+ * must be derived from trigger.command (not skill.name).
+ */
+function commandFileBaseName(skill: Skill): string {
+  const command = skill.trigger.command.startsWith("/")
+    ? skill.trigger.command.slice(1)
+    : skill.trigger.command;
+  return command.replace(/[^a-z0-9-]/gi, "-");
+}
+
+function renderMarkdownSkill(skill: Skill): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# ${skill.name}`);
+  lines.push("");
+  lines.push(skill.description);
+  lines.push("");
+
+  // Trigger
+  lines.push("## Trigger");
+  lines.push("");
+  lines.push(`\`${skill.trigger.command}\``);
+  if (skill.trigger.aliases && skill.trigger.aliases.length > 0) {
+    lines.push("");
+    lines.push(`Aliases: ${skill.trigger.aliases.join(", ")}`);
+  }
+  lines.push("");
+
+  // Parameters
+  if (skill.parameters.length > 0) {
+    lines.push("## Parameters");
+    lines.push("");
+    lines.push("Prompt for all required parameters when this command is invoked.");
+    lines.push("");
+    for (const param of skill.parameters) {
+      const required = param.required ? "(required)" : "(optional)";
+      const defaultVal = param.default !== undefined ? ` [default: ${param.default}]` : "";
+      lines.push(`- **${param.name}** \`${param.type}\` ${required}${defaultVal}`);
+      if (param.description) {
+        lines.push(`  ${param.description}`);
+      }
+      if (param.options) {
+        lines.push(`  Options: ${param.options.join(", ")}`);
+      }
+    }
+    lines.push("");
+  }
+
+  // Prompt template
+  lines.push("## Prompt");
+  lines.push("");
+  if (skill.system) {
+    lines.push("**System:**");
+    lines.push("```");
+    lines.push(skill.system);
+    lines.push("```");
+    lines.push("");
+  }
+  lines.push("**User:**");
+  lines.push("```");
+  lines.push(skill.prompt);
+  lines.push("```");
+  lines.push("");
+
+  // Metadata
+  if (skill.metadata) {
+    lines.push("## Metadata");
+    lines.push("");
+    if (skill.metadata.author) {
+      lines.push(`- Author: ${skill.metadata.author}`);
+    }
+    if (skill.metadata.license) {
+      lines.push(`- License: ${skill.metadata.license}`);
+    }
+    if (skill.metadata.tags && skill.metadata.tags.length > 0) {
+      lines.push(`- Tags: ${skill.metadata.tags.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+/**
  * Claude Code skill renderer.
  * Renders skills as markdown with slash command documentation.
  */
@@ -36,80 +122,62 @@ export class ClaudeCodeSkillRenderer implements SkillRenderer {
   readonly displayName = "Claude Code";
 
   render(skill: Skill): string {
-    const lines: string[] = [];
-
-    // Header
-    lines.push(`# ${skill.name}`);
-    lines.push("");
-    lines.push(skill.description);
-    lines.push("");
-
-    // Trigger
-    lines.push(`## Trigger`);
-    lines.push("");
-    lines.push(`\`${skill.trigger.command}\``);
-    if (skill.trigger.aliases && skill.trigger.aliases.length > 0) {
-      lines.push("");
-      lines.push(`Aliases: ${skill.trigger.aliases.join(", ")}`);
-    }
-    lines.push("");
-
-    // Parameters
-    if (skill.parameters.length > 0) {
-      lines.push("## Parameters");
-      lines.push("");
-      for (const param of skill.parameters) {
-        const required = param.required ? "(required)" : "(optional)";
-        const defaultVal = param.default !== undefined ? ` [default: ${param.default}]` : "";
-        lines.push(`- **${param.name}** \`${param.type}\` ${required}${defaultVal}`);
-        if (param.description) {
-          lines.push(`  ${param.description}`);
-        }
-        if (param.options) {
-          lines.push(`  Options: ${param.options.join(", ")}`);
-        }
-      }
-      lines.push("");
-    }
-
-    // Prompt template
-    lines.push("## Prompt");
-    lines.push("");
-    if (skill.system) {
-      lines.push("**System:**");
-      lines.push("```");
-      lines.push(skill.system);
-      lines.push("```");
-      lines.push("");
-    }
-    lines.push("**User:**");
-    lines.push("```");
-    lines.push(skill.prompt);
-    lines.push("```");
-    lines.push("");
-
-    // Metadata
-    if (skill.metadata) {
-      lines.push("## Metadata");
-      lines.push("");
-      if (skill.metadata.author) {
-        lines.push(`- Author: ${skill.metadata.author}`);
-      }
-      if (skill.metadata.license) {
-        lines.push(`- License: ${skill.metadata.license}`);
-      }
-      if (skill.metadata.tags && skill.metadata.tags.length > 0) {
-        lines.push(`- Tags: ${skill.metadata.tags.join(", ")}`);
-      }
-      lines.push("");
-    }
-
-    return lines.join("\n").trimEnd();
+    return renderMarkdownSkill(skill);
   }
 
   getFilename(skill: Skill): string {
-    const safeName = skill.name.replace(/[^a-z0-9-]/gi, "-");
-    return `skill-${safeName}.md`;
+    return `${commandFileBaseName(skill)}.md`;
+  }
+}
+
+/**
+ * Codex skill renderer.
+ * Uses markdown command files derived from slash command names.
+ */
+export class CodexSkillRenderer implements SkillRenderer {
+  readonly toolId = "codex";
+  readonly displayName = "Codex CLI";
+
+  render(skill: Skill): string {
+    return renderMarkdownSkill(skill);
+  }
+
+  getFilename(skill: Skill): string {
+    return `${commandFileBaseName(skill)}.md`;
+  }
+}
+
+/**
+ * OpenCode skill renderer.
+ * Uses markdown command files derived from slash command names.
+ */
+export class OpenCodeSkillRenderer implements SkillRenderer {
+  readonly toolId = "opencode";
+  readonly displayName = "OpenCode";
+
+  render(skill: Skill): string {
+    return renderMarkdownSkill(skill);
+  }
+
+  getFilename(skill: Skill): string {
+    return `${commandFileBaseName(skill)}.md`;
+  }
+}
+
+/**
+ * GitHub Copilot skill renderer.
+ * Uses markdown command files derived from slash command names.
+ */
+export class CopilotSkillRenderer implements SkillRenderer {
+  readonly toolId = "copilot";
+  readonly displayName = "GitHub Copilot";
+
+  render(skill: Skill): string {
+    return renderMarkdownSkill(skill);
+  }
+
+  getFilename(skill: Skill): string {
+    return `${commandFileBaseName(skill)}.md`;
   }
 }
 
@@ -152,6 +220,8 @@ export class CursorSkillRenderer implements SkillRenderer {
     if (skill.parameters.length > 0) {
       lines.push("## Parameters");
       lines.push("");
+      lines.push("Prompt for all required parameters when this command is invoked.");
+      lines.push("");
       for (const param of skill.parameters) {
         const required = param.required ? "required" : "optional";
         lines.push(
@@ -174,8 +244,7 @@ export class CursorSkillRenderer implements SkillRenderer {
   }
 
   getFilename(skill: Skill): string {
-    const safeName = skill.name.replace(/[^a-z0-9-]/gi, "-");
-    return `${safeName}.mdc`;
+    return `${commandFileBaseName(skill)}.mdc`;
   }
 }
 
@@ -197,7 +266,7 @@ export class AiderSkillRenderer implements SkillRenderer {
     lines.push("");
 
     // Trigger
-    lines.push(`## Invocation`);
+    lines.push("## Invocation");
     lines.push("");
     lines.push(`Use \`${skill.trigger.command}\` to invoke this skill.`);
     lines.push("");
@@ -241,6 +310,9 @@ export class AiderSkillRenderer implements SkillRenderer {
  */
 export const skillRenderers: Record<string, SkillRenderer> = {
   "claude-code": new ClaudeCodeSkillRenderer(),
+  codex: new CodexSkillRenderer(),
+  opencode: new OpenCodeSkillRenderer(),
+  copilot: new CopilotSkillRenderer(),
   cursor: new CursorSkillRenderer(),
   aider: new AiderSkillRenderer(),
 };


### PR DESCRIPTION
## Summary\n- derive output filenames from slash-command triggers for cross-tool invocation\n- add renderers/exports for Codex, Copilot, and OpenCode command surfaces\n- expand skill renderer tests for slash-command command-file generation\n\nCloses #29