### PR TITLE
feat(core): immutable skill installation and usage history (SKILL-011)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ pnpm run lint:fix          # Safe autofix + full lint verification
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
 See [docs/style/markdown-machine-style-guide.md](docs/style/markdown-machine-style-guide.md)
 for markdown and machine-readable standards.
+See [docs/skill-history.md](docs/skill-history.md) for SKILL-011 installation/usage history
+storage and retention policy.
 
 ## Roadmap
 

--- a/docs/skill-history.md
+++ b/docs/skill-history.md
@@ -1,0 +1,25 @@
+# Skill History Storage (SKILL-011)
+
+LAUP core provides append-only history storage for skill installation and usage events.
+
+## Guarantees
+
+- Install events include `skillId`, `projectId`, `version`, `actor`, and `timestamp`
+- Usage events include `skillId`, `projectId`, `invocationCount`, and `timestamp`
+- History is immutable (append-only): only insert, query, and retention pruning are supported
+- Query supports filtering by `skillId` and date range (`startTime` / `endTime`)
+- Retention policy keeps at least 24 months of history
+
+## API
+
+From `@laup/core`:
+
+- `InMemorySkillHistoryStorage`
+- `SqlSkillHistoryStorage`
+- `createSkillHistoryStorage(db)`
+- `MIN_SKILL_HISTORY_RETENTION_MONTHS` (currently `24`)
+
+## Retention behavior
+
+`prune(before?)` never deletes records newer than the policy cutoff (`now - 24 months`).
+If a later `before` date is provided, the storage clamps pruning to the retention cutoff.

--- a/packages/core/src/__tests__/skill-history.test.ts
+++ b/packages/core/src/__tests__/skill-history.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDbAdapter } from "../db-adapter.js";
+import {
+  InMemorySkillHistoryStorage,
+  MIN_SKILL_HISTORY_RETENTION_MONTHS,
+  type SkillHistoryStorage,
+  SqlSkillHistoryStorage,
+} from "../skill-history.js";
+
+describe("skill-history", () => {
+  let storage: SkillHistoryStorage;
+
+  beforeEach(async () => {
+    storage = new InMemorySkillHistoryStorage(() => new Date("2026-03-04T20:00:00.000Z"));
+    await storage.init();
+  });
+
+  it("records immutable install events with project/version/timestamp/actor", async () => {
+    await storage.recordInstall({
+      skillId: "acme/review",
+      projectId: "project-1",
+      version: "1.2.3",
+      actor: "alice",
+      timestamp: "2026-03-04T19:00:00.000Z",
+    });
+
+    const events = await storage.query({ skillId: "acme/review" });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "install",
+      skillId: "acme/review",
+      projectId: "project-1",
+      version: "1.2.3",
+      actor: "alice",
+      timestamp: "2026-03-04T19:00:00.000Z",
+    });
+  });
+
+  it("records usage events with invocation count and timestamp", async () => {
+    await storage.recordUsage({
+      skillId: "acme/review",
+      projectId: "project-1",
+      invocationCount: 7,
+      timestamp: "2026-03-04T19:30:00.000Z",
+    });
+
+    const events = await storage.query({ skillId: "acme/review", type: "usage" });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "usage",
+      invocationCount: 7,
+      timestamp: "2026-03-04T19:30:00.000Z",
+    });
+  });
+
+  it("queries history by skill ID and date range", async () => {
+    await storage.recordUsage({
+      skillId: "acme/review",
+      projectId: "project-1",
+      timestamp: "2026-02-01T10:00:00.000Z",
+    });
+    await storage.recordUsage({
+      skillId: "acme/review",
+      projectId: "project-1",
+      timestamp: "2026-02-15T10:00:00.000Z",
+    });
+    await storage.recordUsage({
+      skillId: "acme/other",
+      projectId: "project-1",
+      timestamp: "2026-02-15T10:00:00.000Z",
+    });
+
+    const events = await storage.query({
+      skillId: "acme/review",
+      startTime: new Date("2026-02-10T00:00:00.000Z"),
+      endTime: new Date("2026-02-20T00:00:00.000Z"),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.skillId).toBe("acme/review");
+    expect(events[0]?.timestamp).toBe("2026-02-15T10:00:00.000Z");
+  });
+
+  it("retains at least 24 months when pruning", async () => {
+    await storage.recordUsage({
+      skillId: "acme/review",
+      projectId: "project-1",
+      timestamp: "2024-03-10T00:00:00.000Z",
+    });
+    await storage.recordUsage({
+      skillId: "acme/review",
+      projectId: "project-1",
+      timestamp: "2024-03-03T23:59:59.000Z",
+    });
+
+    const pruned = await storage.prune(new Date("2026-03-01T00:00:00.000Z"));
+    expect(pruned).toBe(1);
+
+    const remaining = await storage.query({ skillId: "acme/review" });
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.timestamp).toBe("2024-03-10T00:00:00.000Z");
+    expect(MIN_SKILL_HISTORY_RETENTION_MONTHS).toBe(24);
+  });
+
+  it("persists events through sql storage", async () => {
+    const db = new InMemoryDbAdapter();
+    await db.connect();
+
+    const sqlStorage = new SqlSkillHistoryStorage(db, () => new Date("2026-03-04T20:00:00.000Z"));
+    await sqlStorage.init();
+
+    await sqlStorage.recordInstall({
+      skillId: "acme/review",
+      projectId: "project-1",
+      version: "2.0.0",
+      actor: "bob",
+      timestamp: "2026-03-04T18:00:00.000Z",
+    });
+
+    const rows = await db.query<{ type: string; skill_id: string; version: string; actor: string }>(
+      "SELECT type, skill_id, version, actor FROM skill_history_events",
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0]).toMatchObject({
+      type: "install",
+      skill_id: "acme/review",
+      version: "2.0.0",
+      actor: "bob",
+    });
+
+    await db.disconnect();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -490,6 +490,22 @@ export { mergeScopes, SCOPE_PRECEDENCE, scopePrecedence } from "./scope.js";
 export type { ScopeConfig, ScopeLoadResult } from "./scope-loader.js";
 export { getDefaultScopePath, loadScopedDocument, loadScopes } from "./scope-loader.js";
 export type {
+  RecordSkillInstallInput,
+  RecordSkillUsageInput,
+  SkillHistoryEvent,
+  SkillHistoryEventType,
+  SkillHistoryQuery,
+  SkillHistoryStorage,
+  SkillInstallHistoryEvent,
+  SkillUsageHistoryEvent,
+} from "./skill-history.js";
+export {
+  createSkillHistoryStorage,
+  InMemorySkillHistoryStorage,
+  MIN_SKILL_HISTORY_RETENTION_MONTHS,
+  SqlSkillHistoryStorage,
+} from "./skill-history.js";
+export type {
   InstalledSkill,
   SkillInstallStatus,
   SkillQueryFilter,

--- a/packages/core/src/skill-history.ts
+++ b/packages/core/src/skill-history.ts
@@ -1,0 +1,276 @@
+/**
+ * Immutable append-only skill installation and usage history (SKILL-011).
+ */
+
+import type { DbAdapter } from "./db-adapter.js";
+
+export const MIN_SKILL_HISTORY_RETENTION_MONTHS = 24;
+
+export type SkillHistoryEventType = "install" | "usage";
+
+interface SkillHistoryEventBase {
+  id: string;
+  type: SkillHistoryEventType;
+  skillId: string;
+  projectId: string;
+  timestamp: string;
+}
+
+export interface SkillInstallHistoryEvent extends SkillHistoryEventBase {
+  type: "install";
+  version: string;
+  actor: string;
+}
+
+export interface SkillUsageHistoryEvent extends SkillHistoryEventBase {
+  type: "usage";
+  invocationCount: number;
+}
+
+export type SkillHistoryEvent = SkillInstallHistoryEvent | SkillUsageHistoryEvent;
+
+export interface SkillHistoryQuery {
+  skillId?: string;
+  projectId?: string;
+  startTime?: Date;
+  endTime?: Date;
+  type?: SkillHistoryEventType;
+}
+
+export interface RecordSkillInstallInput {
+  skillId: string;
+  projectId: string;
+  version: string;
+  actor: string;
+  timestamp?: string;
+}
+
+export interface RecordSkillUsageInput {
+  skillId: string;
+  projectId: string;
+  invocationCount?: number;
+  timestamp?: string;
+}
+
+export interface SkillHistoryStorage {
+  init(): Promise<void>;
+  recordInstall(input: RecordSkillInstallInput): Promise<string>;
+  recordUsage(input: RecordSkillUsageInput): Promise<string>;
+  query(filter: SkillHistoryQuery): Promise<SkillHistoryEvent[]>;
+  prune(before?: Date): Promise<number>;
+}
+
+function retentionCutoffFrom(now: Date): Date {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - MIN_SKILL_HISTORY_RETENTION_MONTHS,
+      now.getUTCDate(),
+      now.getUTCHours(),
+      now.getUTCMinutes(),
+      now.getUTCSeconds(),
+      now.getUTCMilliseconds(),
+    ),
+  );
+}
+
+function effectivePruneBefore(now: Date, before?: Date): Date {
+  const retentionCutoff = retentionCutoffFrom(now);
+  if (!before) return retentionCutoff;
+  return before.getTime() < retentionCutoff.getTime() ? before : retentionCutoff;
+}
+
+export class InMemorySkillHistoryStorage implements SkillHistoryStorage {
+  private events: SkillHistoryEvent[] = [];
+  private nextId = 1;
+
+  constructor(private now: () => Date = () => new Date()) {}
+
+  async init(): Promise<void> {}
+
+  async recordInstall(input: RecordSkillInstallInput): Promise<string> {
+    const id = `skill_hist_${this.nextId++}`;
+    this.events.push({
+      id,
+      type: "install",
+      skillId: input.skillId,
+      projectId: input.projectId,
+      version: input.version,
+      actor: input.actor,
+      timestamp: input.timestamp ?? this.now().toISOString(),
+    });
+    return id;
+  }
+
+  async recordUsage(input: RecordSkillUsageInput): Promise<string> {
+    const id = `skill_hist_${this.nextId++}`;
+    this.events.push({
+      id,
+      type: "usage",
+      skillId: input.skillId,
+      projectId: input.projectId,
+      invocationCount: input.invocationCount ?? 1,
+      timestamp: input.timestamp ?? this.now().toISOString(),
+    });
+    return id;
+  }
+
+  async query(filter: SkillHistoryQuery): Promise<SkillHistoryEvent[]> {
+    return this.events
+      .filter((event) => {
+        if (filter.type && event.type !== filter.type) return false;
+        if (filter.skillId && event.skillId !== filter.skillId) return false;
+        if (filter.projectId && event.projectId !== filter.projectId) return false;
+
+        const eventTime = new Date(event.timestamp).getTime();
+        if (filter.startTime && eventTime < filter.startTime.getTime()) return false;
+        if (filter.endTime && eventTime >= filter.endTime.getTime()) return false;
+
+        return true;
+      })
+      .sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+  }
+
+  async prune(before?: Date): Promise<number> {
+    const pruneBefore = effectivePruneBefore(this.now(), before);
+    const pruneBeforeMs = pruneBefore.getTime();
+
+    const keep: SkillHistoryEvent[] = [];
+    let pruned = 0;
+    for (const event of this.events) {
+      if (new Date(event.timestamp).getTime() < pruneBeforeMs) {
+        pruned += 1;
+        continue;
+      }
+      keep.push(event);
+    }
+
+    this.events = keep;
+    return pruned;
+  }
+}
+
+export class SqlSkillHistoryStorage implements SkillHistoryStorage {
+  constructor(
+    private db: DbAdapter,
+    private now: () => Date = () => new Date(),
+  ) {}
+
+  async init(): Promise<void> {
+    await this.db.execute(`
+      CREATE TABLE IF NOT EXISTS skill_history_events (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        skill_id TEXT NOT NULL,
+        project_id TEXT NOT NULL,
+        version TEXT,
+        actor TEXT,
+        invocation_count INTEGER,
+        timestamp TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_skill_history_skill_timestamp ON skill_history_events(skill_id, timestamp)`,
+    );
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_skill_history_project_timestamp ON skill_history_events(project_id, timestamp)`,
+    );
+  }
+
+  async recordInstall(input: RecordSkillInstallInput): Promise<string> {
+    const id = `skill_hist_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    await this.db.execute(
+      `INSERT INTO skill_history_events (id, type, skill_id, project_id, version, actor, invocation_count, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        "install",
+        input.skillId,
+        input.projectId,
+        input.version,
+        input.actor,
+        null,
+        input.timestamp ?? this.now().toISOString(),
+      ],
+    );
+    return id;
+  }
+
+  async recordUsage(input: RecordSkillUsageInput): Promise<string> {
+    const id = `skill_hist_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    await this.db.execute(
+      `INSERT INTO skill_history_events (id, type, skill_id, project_id, version, actor, invocation_count, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        "usage",
+        input.skillId,
+        input.projectId,
+        null,
+        null,
+        input.invocationCount ?? 1,
+        input.timestamp ?? this.now().toISOString(),
+      ],
+    );
+    return id;
+  }
+
+  async query(filter: SkillHistoryQuery): Promise<SkillHistoryEvent[]> {
+    const result = await this.db.query<{
+      id: string;
+      type: SkillHistoryEventType;
+      skill_id: string;
+      project_id: string;
+      version: string | null;
+      actor: string | null;
+      invocation_count: number | null;
+      timestamp: string;
+    }>(`SELECT * FROM skill_history_events ORDER BY timestamp ASC`);
+
+    return result.rows
+      .filter((row) => {
+        if (filter.type && row.type !== filter.type) return false;
+        if (filter.skillId && row.skill_id !== filter.skillId) return false;
+        if (filter.projectId && row.project_id !== filter.projectId) return false;
+
+        const eventTime = new Date(row.timestamp).getTime();
+        if (filter.startTime && eventTime < filter.startTime.getTime()) return false;
+        if (filter.endTime && eventTime >= filter.endTime.getTime()) return false;
+
+        return true;
+      })
+      .map((row) => {
+        if (row.type === "install") {
+          return {
+            id: row.id,
+            type: "install",
+            skillId: row.skill_id,
+            projectId: row.project_id,
+            version: row.version ?? "",
+            actor: row.actor ?? "",
+            timestamp: row.timestamp,
+          } satisfies SkillInstallHistoryEvent;
+        }
+
+        return {
+          id: row.id,
+          type: "usage",
+          skillId: row.skill_id,
+          projectId: row.project_id,
+          invocationCount: row.invocation_count ?? 1,
+          timestamp: row.timestamp,
+        } satisfies SkillUsageHistoryEvent;
+      });
+  }
+
+  async prune(before?: Date): Promise<number> {
+    const pruneBefore = effectivePruneBefore(this.now(), before).toISOString();
+    return this.db.execute(`DELETE FROM skill_history_events WHERE timestamp < ?`, [pruneBefore]);
+  }
+}
+
+export function createSkillHistoryStorage(db: DbAdapter): SkillHistoryStorage {
+  return new SqlSkillHistoryStorage(db);
+}


### PR DESCRIPTION
## Summary
- add new append-only `skill-history` storage module in core
- record immutable install events (`skillId`, `projectId`, `version`, `actor`, `timestamp`)
- record immutable usage events (`skillId`, `projectId`, `invocationCount`, `timestamp`)
- add query support by skill/date range (and project/type filters)
- add retention enforcement with minimum 24-month policy (`MIN_SKILL_HISTORY_RETENTION_MONTHS = 24`)
- expose the new API from `@laup/core` index
- add tests for in-memory + sql storage behavior and retention clamping
- add `docs/skill-history.md` and link from README

## Validation
I ran the requested checks and captured outcomes:
- `pnpm lint` ❌ fails due to existing repository-wide Biome findings unrelated to this change (example: `packages/core/src/__tests__/audit-storage.test.ts` and many others).
- `pnpm typecheck` ❌ fails in existing adapter package resolution (`packages/adapters/codex/src/index.ts` cannot resolve `@laup/core`).
- `pnpm test:run` ❌ fails in existing adapter/config-hub suites with unresolved `@laup/core` imports; however, core tests including the new suite pass.
- `pnpm test:run packages/core/src/__tests__/skill-history.test.ts` ✅ pass

## Notes
- History APIs are append-only by design (no update/delete mutators), with controlled pruning for retention management.

Closes #34
