### PR TITLE
feat(core): support exact key lookup by ID or explicit key

### DIFF
--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -126,4 +126,55 @@ describe("memory-store", () => {
     });
     expect(otherOrg).toHaveLength(0);
   });
+
+  it("assigns a system ID when omitted and supports exact ID lookup", async () => {
+    const created = await store.write({
+      content: "remember this",
+      scope: "project",
+      context,
+    });
+
+    expect(created.id).toMatch(/^mem_/);
+
+    const fetched = await store.getById(created.id, context);
+    expect(fetched?.id).toBe(created.id);
+  });
+
+  it("supports exact key lookup for memories with explicit keys", async () => {
+    await store.write({
+      id: "project_with_key",
+      key: "deploy-checklist",
+      content: "Run migrations before deploy",
+      scope: "project",
+      context,
+    });
+
+    const byKey = await store.getByKey("deploy-checklist", context);
+    expect(byKey?.id).toBe("project_with_key");
+  });
+
+  it("returns null for non-existent ID or key", async () => {
+    expect(await store.getById("does_not_exist", context)).toBeNull();
+    expect(await store.getByKey("does_not_exist", context)).toBeNull();
+  });
+
+  it("rejects duplicate keys in the same org", async () => {
+    await store.write({
+      id: "one",
+      key: "shared-key",
+      content: "first",
+      scope: "project",
+      context,
+    });
+
+    await expect(
+      store.write({
+        id: "two",
+        key: "shared-key",
+        content: "second",
+        scope: "org",
+        context,
+      }),
+    ).rejects.toThrow(/already in use|unique/i);
+  });
 });

--- a/packages/core/src/memory-store.ts
+++ b/packages/core/src/memory-store.ts
@@ -14,6 +14,7 @@ export interface MemoryContext {
 
 export interface MemoryRecord {
   id: string;
+  key?: string;
   content: string;
   scope: MemoryScope;
   orgId: string;
@@ -26,6 +27,7 @@ export interface MemoryRecord {
 
 export interface MemoryWriteInput {
   id?: string;
+  key?: string;
   content: string;
   scope: MemoryScope;
   context: MemoryContext;
@@ -48,6 +50,11 @@ export interface MemoryStore {
   ): Promise<MemoryRecord[]>;
   getById(
     id: string,
+    context: MemoryContext,
+    options?: MemoryReadOptions,
+  ): Promise<MemoryRecord | null>;
+  getByKey(
+    key: string,
     context: MemoryContext,
     options?: MemoryReadOptions,
   ): Promise<MemoryRecord | null>;
@@ -111,6 +118,11 @@ function canRead(
 
 export class InMemoryMemoryStore implements MemoryStore {
   private records = new Map<string, MemoryRecord>();
+  private keyToId = new Map<string, string>();
+
+  private makeKeyIndex(orgId: string, key: string): string {
+    return `${orgId}:${key}`;
+  }
 
   async init(): Promise<void> {}
 
@@ -129,8 +141,18 @@ export class InMemoryMemoryStore implements MemoryStore {
         ? new Date(now.getTime() + SESSION_TTL_MS).toISOString()
         : undefined;
 
+    const key = input.key ?? existing?.key;
+    if (key) {
+      const keyIndex = this.makeKeyIndex(scopeContext.orgId, key);
+      const currentId = this.keyToId.get(keyIndex);
+      if (currentId && currentId !== id) {
+        throw new Error(`Memory key is already in use for org ${scopeContext.orgId}: ${key}`);
+      }
+    }
+
     const record: MemoryRecord = {
       id,
+      ...(key ? { key } : {}),
       content: input.content,
       scope: input.scope,
       createdAt: existing?.createdAt ?? now.toISOString(),
@@ -138,6 +160,13 @@ export class InMemoryMemoryStore implements MemoryStore {
       ...(expiresAt ? { expiresAt } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
     };
+
+    if (existing?.key && existing.key !== key) {
+      this.keyToId.delete(this.makeKeyIndex(existing.orgId, existing.key));
+    }
+    if (key) {
+      this.keyToId.set(this.makeKeyIndex(scopeContext.orgId, key), id);
+    }
 
     this.records.set(id, record);
     return record;
@@ -175,11 +204,24 @@ export class InMemoryMemoryStore implements MemoryStore {
     return canReadAtAnyScope ? record : null;
   }
 
+  async getByKey(
+    key: string,
+    context: MemoryContext,
+    options?: MemoryReadOptions,
+  ): Promise<MemoryRecord | null> {
+    const id = this.keyToId.get(this.makeKeyIndex(context.orgId, key));
+    if (!id) return null;
+    return this.getById(id, context, options);
+  }
+
   async pruneExpired(now = new Date()): Promise<number> {
     let removed = 0;
     for (const [id, record] of this.records) {
       if (isExpired(record, now)) {
         this.records.delete(id);
+        if (record.key) {
+          this.keyToId.delete(this.makeKeyIndex(record.orgId, record.key));
+        }
         removed += 1;
       }
     }
@@ -189,6 +231,7 @@ export class InMemoryMemoryStore implements MemoryStore {
 
 interface MemoryRow {
   id: string;
+  key: string | null;
   content: string;
   scope: MemoryScope;
   org_id: string;
@@ -206,6 +249,7 @@ export class SqlMemoryStore implements MemoryStore {
     await this.db.execute(`
       CREATE TABLE IF NOT EXISTS memories (
         id TEXT PRIMARY KEY,
+        key TEXT,
         content TEXT NOT NULL,
         scope TEXT NOT NULL,
         org_id TEXT NOT NULL,
@@ -220,6 +264,9 @@ export class SqlMemoryStore implements MemoryStore {
     await this.db.execute(`CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)`);
     await this.db.execute(`CREATE INDEX IF NOT EXISTS idx_memories_org ON memories(org_id)`);
     await this.db.execute(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_org_key_unique ON memories(org_id, key) WHERE key IS NOT NULL`,
+    );
+    await this.db.execute(
       `CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project_id)`,
     );
     await this.db.execute(
@@ -233,10 +280,11 @@ export class SqlMemoryStore implements MemoryStore {
   async write(input: MemoryWriteInput): Promise<MemoryRecord> {
     const id = input.id ?? randomId();
     const now = input.now ?? new Date();
-    const existing = await this.db.queryOne<{ scope: string; created_at: string }>(
-      `SELECT scope, created_at FROM memories WHERE id = ?`,
-      [id],
-    );
+    const existing = await this.db.queryOne<{
+      scope: string;
+      created_at: string;
+      key: string | null;
+    }>(`SELECT scope, created_at, key FROM memories WHERE id = ?`, [id]);
 
     if (existing && existing.scope !== input.scope) {
       throw new Error(`Memory scope is immutable for id ${id}`);
@@ -246,12 +294,14 @@ export class SqlMemoryStore implements MemoryStore {
     const expiresAt =
       input.scope === "session" ? new Date(now.getTime() + SESSION_TTL_MS).toISOString() : null;
     const createdAt = existing?.created_at ?? now.toISOString();
+    const key = input.key ?? existing?.key ?? null;
 
     await this.db.execute(
-      `INSERT OR REPLACE INTO memories (id, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO memories (id, key, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
+        key,
         input.content,
         input.scope,
         scopeContext.orgId,
@@ -265,6 +315,7 @@ export class SqlMemoryStore implements MemoryStore {
 
     return {
       id,
+      ...(key ? { key } : {}),
       content: input.content,
       scope: input.scope,
       orgId: scopeContext.orgId,
@@ -296,7 +347,7 @@ export class SqlMemoryStore implements MemoryStore {
     const params: (string | null)[] = [context.orgId, ...allowedScopes, now];
 
     let query = `
-      SELECT id, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at
+      SELECT id, key, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at
       FROM memories
       WHERE org_id = ?
         AND scope IN (${placeholders})
@@ -328,10 +379,38 @@ export class SqlMemoryStore implements MemoryStore {
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
 
     const row = await this.db.queryOne<MemoryRow>(
-      `SELECT id, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at
+      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at
        FROM memories
        WHERE id = ?`,
       [id],
+    );
+
+    if (!row) return null;
+
+    const record = this.rowToRecord(row);
+    if (isExpired(record, now)) return null;
+
+    const canReadAtAnyScope =
+      canRead(record, "session", context, includeShared) ||
+      canRead(record, "project", context, includeShared) ||
+      canRead(record, "org", context, includeShared);
+
+    return canReadAtAnyScope ? record : null;
+  }
+
+  async getByKey(
+    key: string,
+    context: MemoryContext,
+    options?: MemoryReadOptions,
+  ): Promise<MemoryRecord | null> {
+    const now = options?.now ?? new Date();
+    const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+
+    const row = await this.db.queryOne<MemoryRow>(
+      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, created_at, expires_at
+       FROM memories
+       WHERE org_id = ? AND key = ?`,
+      [context.orgId, key],
     );
 
     if (!row) return null;
@@ -363,6 +442,7 @@ export class SqlMemoryStore implements MemoryStore {
 
     return {
       id: String(row.id),
+      ...(row.key ? { key: String(row.key) } : {}),
       content: String(row.content),
       scope: row.scope as MemoryScope,
       orgId: String(row.org_id),


### PR DESCRIPTION
## Summary
- add optional explicit `key` support to memory records and writes
- implement exact lookup by key in both in-memory and SQL memory stores
- enforce per-org key uniqueness and add a SQL unique index for key lookup
- add tests for system-assigned IDs, key lookup, missing lookups, and duplicate key rejection

## Validation
- pnpm vitest run packages/core/src/__tests__/memory-store.test.ts
- pnpm --filter @laup/core typecheck

Closes #41
