### PR TITLE
feat(hand): define standard context packet format (HAND-001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ See [docs/skill-history.md](docs/skill-history.md) for SKILL-011 installation/us
 storage and retention policy.
 See [docs/memory-semantic-retrieval.md](docs/memory-semantic-retrieval.md) for MEM-002
 semantic retrieval behavior and API usage.
+See [docs/context-packet-format.md](docs/context-packet-format.md) for HAND-001
+standard context packet format requirements.
 
 ## Roadmap
 

--- a/docs/context-packet-format.md
+++ b/docs/context-packet-format.md
@@ -1,0 +1,42 @@
+# Standard Context Packet Format (HAND-001)
+
+This document defines the standard handoff context packet used for agent-to-agent transfers.
+
+Implementation source: `packages/core/src/handoff-schema.ts` (`ContextPacketSchema`)
+
+## Versioning
+
+- `schemaVersion` **MUST** follow semantic versioning (`MAJOR.MINOR.PATCH`)
+- Example: `1.0.0`
+
+## Required Fields
+
+The packet **MUST** include all of the following required fields:
+
+- `packetId` (string)
+- `schemaVersion` (semver string)
+- `sendingTool` (string)
+- `receivingTool` (string)
+- `task` (object)
+- `workingContext` (object)
+- `memoryRefs` (string[])
+- `conversationSummary` (string)
+- `constraints` (string[])
+- `permissionPolicy` (object)
+- `timestamp` (ISO datetime string)
+
+## Tool-Agnostic Design
+
+The schema is tool-agnostic:
+
+- `sendingTool` / `receivingTool` are open string identifiers
+- `task`, `workingContext`, and `permissionPolicy` are generic object payloads
+
+## Machine Validation
+
+The format is machine-validatable via Zod schema:
+
+- `ContextPacketSchema.safeParse(packet)`
+- `ContextPacketSchema.parse(packet)`
+
+This satisfies the HAND-001 requirement for a structured, serializable/deserializable packet format.

--- a/packages/core/src/__tests__/handoff-schema.test.ts
+++ b/packages/core/src/__tests__/handoff-schema.test.ts
@@ -11,29 +11,27 @@ import {
 
 describe("handoff-schema", () => {
   const samplePacket: ContextPacket = {
-    id: "packet-1",
-    schemaVersion: "1.0",
-    sourceAgent: "agent-a",
-    targetAgent: "agent-b",
-    mode: "sync",
-    routing: "direct",
-    timeoutSeconds: 60,
-    conversation: {
-      messages: [
-        { role: "user", content: "Help me with this task" },
-        { role: "assistant", content: "Sure, I can help" },
-      ],
-      task: "Code review",
+    packetId: "packet-1",
+    schemaVersion: "1.0.0",
+    sendingTool: "codex",
+    receivingTool: "claude-code",
+    task: {
+      type: "code-review",
+      title: "Review auth middleware",
     },
-    state: {
+    workingContext: {
       currentFile: "src/main.ts",
       lineNumber: 42,
     },
-    compressed: false,
-    metadata: {
-      createdAt: "2026-01-15T10:00:00Z",
-      priority: "normal",
+    memoryRefs: ["mem://handoff/123"],
+    conversationSummary: "User asked for help with a code review.",
+    constraints: ["Do not modify public API"],
+    permissionPolicy: {
+      allow: ["read", "write"],
+      deny: ["network"],
     },
+    timestamp: "2026-01-15T10:00:00Z",
+    compressed: false,
   };
 
   describe("ContextPacketSchema", () => {
@@ -42,33 +40,42 @@ describe("handoff-schema", () => {
       expect(result.success).toBe(true);
     });
 
-    it("validates minimal packet", () => {
+    it("requires all HAND-001 fields", () => {
       const minimal = {
-        id: "p-1",
-        sourceAgent: "agent-a",
+        packetId: "p-1",
+        schemaVersion: "1.0.0",
+        sendingTool: "codex",
+        receivingTool: "claude-code",
+        task: {},
+        workingContext: {},
+        memoryRefs: [],
+        conversationSummary: "summary",
+        constraints: [],
+        permissionPolicy: {},
+        timestamp: "2026-01-15T10:00:00Z",
       };
       const result = ContextPacketSchema.safeParse(minimal);
       expect(result.success).toBe(true);
     });
 
-    it("rejects packet without id", () => {
-      const invalid = { ...samplePacket, id: undefined };
+    it("rejects packet without packetId", () => {
+      const invalid = { ...samplePacket, packetId: undefined };
       const result = ContextPacketSchema.safeParse(invalid);
       expect(result.success).toBe(false);
     });
 
-    it("validates async mode", () => {
-      const asyncPacket = { ...samplePacket, mode: "async" };
-      const result = ContextPacketSchema.safeParse(asyncPacket);
-      expect(result.success).toBe(true);
+    it("requires semver schemaVersion", () => {
+      const invalidVersion = { ...samplePacket, schemaVersion: "1.0" };
+      const result = ContextPacketSchema.safeParse(invalidVersion);
+      expect(result.success).toBe(false);
     });
 
     it("validates with field subset", () => {
       const withSubset: ContextPacket = {
         ...samplePacket,
         fieldSubset: [
-          { path: "conversation.task", required: true },
-          { path: "state.currentFile", redact: false },
+          { path: "task.title", required: true },
+          { path: "workingContext.currentFile", redact: false },
         ],
       };
       const result = ContextPacketSchema.safeParse(withSubset);
@@ -97,7 +104,7 @@ describe("handoff-schema", () => {
     it("warns about sensitive field names", () => {
       const sensitivePacket: ContextPacket = {
         ...samplePacket,
-        state: {
+        workingContext: {
           password: "secret123",
           api_key: "sk-xxx",
         },
@@ -107,12 +114,10 @@ describe("handoff-schema", () => {
       expect(result.issues.some((i) => i.field.includes("password"))).toBe(true);
     });
 
-    it("warns about PII in messages", () => {
+    it("warns about PII in conversation summary", () => {
       const piiPacket: ContextPacket = {
         ...samplePacket,
-        conversation: {
-          messages: [{ role: "user", content: "My email is test@example.com" }],
-        },
+        conversationSummary: "My email is test@example.com",
       };
       const result = validatePacketSecurity(piiPacket);
       expect(result.issues.some((i) => i.message.includes("PII"))).toBe(true);
@@ -127,12 +132,7 @@ describe("handoff-schema", () => {
     it("returns true for large packets", () => {
       const largePacket: ContextPacket = {
         ...samplePacket,
-        conversation: {
-          messages: Array(100).fill({
-            role: "user",
-            content: "A".repeat(1000),
-          }),
-        },
+        conversationSummary: "A".repeat(100_000),
       };
       expect(shouldCompressPacket(largePacket)).toBe(true);
     });
@@ -153,12 +153,12 @@ describe("handoff-schema", () => {
   describe("createPartialPacket (HAND-009)", () => {
     it("extracts specified fields", () => {
       const fields: ContextField[] = [
-        { path: "conversation.task", required: false },
-        { path: "state.currentFile", required: false },
+        { path: "task.title", required: false },
+        { path: "workingContext.currentFile", required: false },
       ];
       const partial = createPartialPacket(samplePacket, fields);
-      expect(partial.id).toBe(samplePacket.id);
-      expect((partial as Record<string, unknown>)["conversation"]).toBeDefined();
+      expect(partial.packetId).toBe(samplePacket.packetId);
+      expect(partial).toHaveProperty("task");
     });
 
     it("throws for missing required field", () => {
@@ -167,11 +167,13 @@ describe("handoff-schema", () => {
     });
 
     it("redacts sensitive fields", () => {
-      const fields: ContextField[] = [{ path: "state.currentFile", redact: true, required: false }];
+      const fields: ContextField[] = [
+        { path: "workingContext.currentFile", redact: true, required: false },
+      ];
       const partial = createPartialPacket(samplePacket, fields);
-      expect((partial as { state?: { currentFile?: string } }).state?.currentFile).toBe(
-        "[REDACTED]",
-      );
+      expect(
+        (partial as { workingContext?: { currentFile?: string } }).workingContext?.currentFile,
+      ).toBe("[REDACTED]");
     });
   });
 });

--- a/packages/core/src/handoff-schema.ts
+++ b/packages/core/src/handoff-schema.ts
@@ -53,53 +53,42 @@ export const ContextFieldSchema = z.object({
 export type ContextField = z.infer<typeof ContextFieldSchema>;
 
 /**
- * Context packet for handoff (HAND-001 to HAND-003).
+ * Standard context packet format for handoff (HAND-001).
+ * Tool-agnostic by design: tool fields are open strings and context fields are generic records.
  */
 export const ContextPacketSchema = z.object({
   /** Unique packet ID */
-  id: z.string(),
+  packetId: z.string().min(1),
 
-  /** Schema version */
-  schemaVersion: z.string().default("1.0"),
+  /** Schema version (semver) */
+  schemaVersion: z.string().regex(/^\d+\.\d+\.\d+$/),
 
-  /** Sending agent ID */
-  sourceAgent: z.string(),
+  /** Sending tool identifier */
+  sendingTool: z.string().min(1),
 
-  /** Target agent ID (for direct routing) */
-  targetAgent: z.string().optional(),
+  /** Receiving tool identifier */
+  receivingTool: z.string().min(1),
 
-  /** Handoff mode */
-  mode: HandoffModeSchema.default("sync"),
+  /** Current task payload */
+  task: z.record(z.string(), z.unknown()),
 
-  /** Routing policy */
-  routing: HandoffRoutingSchema.default("direct"),
+  /** Working context payload */
+  workingContext: z.record(z.string(), z.unknown()),
 
-  /** Timeout in seconds (for sync mode) */
-  timeoutSeconds: z.number().min(1).max(300).default(60),
+  /** Memory references */
+  memoryRefs: z.array(z.string()),
 
-  /** Conversation context */
-  conversation: z
-    .object({
-      /** Recent messages */
-      messages: z.array(
-        z.object({
-          role: z.enum(["user", "assistant", "system"]),
-          content: z.string(),
-          timestamp: z.string().optional(),
-        }),
-      ),
-      /** Current task/goal */
-      task: z.string().optional(),
-      /** Relevant files/documents */
-      files: z.array(z.string()).optional(),
-    })
-    .optional(),
+  /** Conversation summary */
+  conversationSummary: z.string(),
 
-  /** Session state */
-  state: z.record(z.string(), z.unknown()).optional(),
+  /** Constraints to apply during handoff */
+  constraints: z.array(z.string()),
 
-  /** Capabilities required from receiver */
-  requiredCapabilities: z.array(z.string()).optional(),
+  /** Permission policy payload */
+  permissionPolicy: z.record(z.string(), z.unknown()),
+
+  /** Creation timestamp */
+  timestamp: z.string().datetime(),
 
   /** Field subset for partial handoff (HAND-009) */
   fieldSubset: z.array(ContextFieldSchema).optional(),
@@ -112,20 +101,6 @@ export const ContextPacketSchema = z.object({
 
   /** Original size before compression */
   originalSizeBytes: z.number().optional(),
-
-  /** Metadata */
-  metadata: z
-    .object({
-      /** Creation timestamp */
-      createdAt: z.string(),
-      /** Priority */
-      priority: z.enum(["low", "normal", "high", "urgent"]).default("normal"),
-      /** TTL in seconds */
-      ttlSeconds: z.number().optional(),
-      /** Tags for categorization */
-      tags: z.array(z.string()).optional(),
-    })
-    .optional(),
 });
 
 export type ContextPacket = z.infer<typeof ContextPacketSchema>;
@@ -251,42 +226,36 @@ export interface SecurityValidationResult {
 export function validatePacketSecurity(packet: ContextPacket): SecurityValidationResult {
   const issues: SecurityValidationResult["issues"] = [];
 
-  // Check for sensitive patterns in state
-  if (packet.state) {
-    const sensitivePatterns = [/password/i, /secret/i, /api_key/i, /token/i, /credential/i];
+  // Check for sensitive patterns in working context keys
+  const sensitivePatterns = [/password/i, /secret/i, /api_key/i, /token/i, /credential/i];
 
-    for (const key of Object.keys(packet.state)) {
-      for (const pattern of sensitivePatterns) {
-        if (pattern.test(key)) {
-          issues.push({
-            severity: "warning",
-            field: `state.${key}`,
-            message: `Field "${key}" may contain sensitive data`,
-          });
-        }
+  for (const key of Object.keys(packet.workingContext)) {
+    for (const pattern of sensitivePatterns) {
+      if (pattern.test(key)) {
+        issues.push({
+          severity: "warning",
+          field: `workingContext.${key}`,
+          message: `Field "${key}" may contain sensitive data`,
+        });
       }
     }
   }
 
-  // Check conversation for PII patterns
-  if (packet.conversation?.messages) {
-    const piiPatterns = [
-      /\b\d{3}-\d{2}-\d{4}\b/, // SSN
-      /\b\d{16}\b/, // Credit card
-      /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, // Email
-    ];
+  // Check conversation summary for PII patterns
+  const piiPatterns = [
+    /\b\d{3}-\d{2}-\d{4}\b/, // SSN
+    /\b\d{16}\b/, // Credit card
+    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, // Email
+  ];
 
-    for (const msg of packet.conversation.messages) {
-      for (const pattern of piiPatterns) {
-        if (pattern.test(msg.content)) {
-          issues.push({
-            severity: "warning",
-            field: "conversation.messages",
-            message: "Message may contain PII",
-          });
-          break;
-        }
-      }
+  for (const pattern of piiPatterns) {
+    if (pattern.test(packet.conversationSummary)) {
+      issues.push({
+        severity: "warning",
+        field: "conversationSummary",
+        message: "Conversation summary may contain PII",
+      });
+      break;
     }
   }
 
@@ -321,10 +290,17 @@ export function createPartialPacket(
   fields: ContextField[],
 ): Partial<ContextPacket> {
   const partial: Partial<ContextPacket> = {
-    id: packet.id,
+    packetId: packet.packetId,
     schemaVersion: packet.schemaVersion,
-    sourceAgent: packet.sourceAgent,
-    mode: packet.mode,
+    sendingTool: packet.sendingTool,
+    receivingTool: packet.receivingTool,
+    task: packet.task,
+    workingContext: packet.workingContext,
+    memoryRefs: packet.memoryRefs,
+    conversationSummary: packet.conversationSummary,
+    constraints: packet.constraints,
+    permissionPolicy: packet.permissionPolicy,
+    timestamp: packet.timestamp,
   };
 
   for (const field of fields) {


### PR DESCRIPTION
## Summary
- implement a HAND-001 standard context packet schema in `@laup/core`
- require the exact HAND-001 fields: `packetId`, `schemaVersion`, `sendingTool`, `receivingTool`, `task`, `workingContext`, `memoryRefs`, `conversationSummary`, `constraints`, `permissionPolicy`, `timestamp`
- enforce semver for `schemaVersion` and ISO datetime for `timestamp`
- keep schema tool-agnostic via open tool identifiers and generic object payloads
- update handoff schema tests for required fields and semver validation
- add docs at `docs/context-packet-format.md` and link it from README

## Validation
- `pnpm biome check packages/core/src/handoff-schema.ts packages/core/src/__tests__/handoff-schema.test.ts`
- `pnpm vitest run packages/core/src/__tests__/handoff-schema.test.ts packages/core/src/__tests__/index.test.ts`
- `pnpm --filter @laup/core typecheck`
- `pnpm markdownlint-cli2 README.md docs/context-packet-format.md`

Closes #74
