### PR TITLE
feat(core): support Mem0 add/search/delete integration patterns

### DIFF
--- a/packages/core/src/__tests__/index.test.ts
+++ b/packages/core/src/__tests__/index.test.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { ParseError, parseCanonicalString, validateCanonical } from "../index.js";
+import {
+  DefaultMem0ContextResolver,
+  Mem0MemoryClient,
+  ParseError,
+  parseCanonicalString,
+  validateCanonical,
+} from "../index.js";
 
 const fixture = (name: string) =>
   readFileSync(join(import.meta.dirname, "fixtures", name), "utf-8");
@@ -37,6 +43,13 @@ describe("parseCanonicalString", () => {
   it("throws ParseError for malformed YAML frontmatter", () => {
     const malformed = "---\nversion: [unclosed\n---\n\n# Body";
     expect(() => parseCanonicalString(malformed)).toThrow(ParseError);
+  });
+});
+
+describe("public exports", () => {
+  it("exports Mem0 compatibility classes", () => {
+    expect(DefaultMem0ContextResolver).toBeTypeOf("function");
+    expect(Mem0MemoryClient).toBeTypeOf("function");
   });
 });
 

--- a/packages/core/src/__tests__/memory-mem0.test.ts
+++ b/packages/core/src/__tests__/memory-mem0.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { DefaultMem0ContextResolver, Mem0MemoryClient } from "../memory-mem0.js";
+import { InMemoryMemoryStore, type MemoryStore } from "../memory-store.js";
+
+describe("Mem0MemoryClient", () => {
+  it("adds memories from string input with Mem0 metadata", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new Mem0MemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultMem0ContextResolver({ orgId: "org-default" }),
+    );
+
+    const records = await client.add("Remember this", {
+      user_id: "org-1",
+      metadata: { topic: "notes" },
+    });
+
+    expect(records).toHaveLength(1);
+    const record = records[0];
+    expect(record?.content).toBe("Remember this");
+    expect(record?.sourceToolId).toBe("mem0");
+    expect(record?.metadata).toMatchObject({ source: "mem0", role: "user", topic: "notes" });
+  });
+
+  it("searches memories using mapped Mem0 context, filters, and limit", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new Mem0MemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultMem0ContextResolver({ orgId: "org-default" }),
+    );
+
+    await client.add(
+      [
+        { role: "user", content: "Deploy to production after review" },
+        { role: "assistant", content: "Staging checklist is complete" },
+      ],
+      {
+        user_id: "org-1",
+        agent_id: "project-1",
+        run_id: "session-1",
+        metadata: { env: "prod" },
+      },
+    );
+
+    await client.add("Deploy docs first", {
+      user_id: "org-1",
+      agent_id: "project-1",
+      run_id: "session-1",
+      metadata: { env: "staging" },
+    });
+
+    const results = await client.search({
+      query: "deploy production",
+      user_id: "org-1",
+      agent_id: "project-1",
+      run_id: "session-1",
+      filters: { env: "prod" },
+      limit: 1,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.memory).toContain("Deploy");
+    expect(results[0]?.metadata).toMatchObject({ env: "prod" });
+    expect(results[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("deletes memories by id with either string id or params object", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new Mem0MemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultMem0ContextResolver({ orgId: "org-1" }),
+    );
+
+    const records = await client.add("Delete me", { user_id: "org-1" });
+    const record = records[0];
+    expect(record).toBeDefined();
+
+    const deletedViaString = await client.delete(record?.id ?? "");
+    expect(deletedViaString).toEqual({ id: record?.id, deleted: true });
+
+    const records2 = await client.add("Delete me too", { user_id: "org-1" });
+    const record2 = records2[0];
+    expect(record2).toBeDefined();
+
+    const deletedViaParams = await client.delete({
+      memory_id: record2?.id ?? "",
+      user_id: "org-1",
+    });
+    expect(deletedViaParams).toEqual({ id: record2?.id, deleted: true });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -289,6 +289,19 @@ export {
   evaluateMcpVersion,
 } from "./mcp-versioning.js";
 export type {
+  Mem0AddParams,
+  Mem0CompatibleMemoryClient,
+  Mem0ContextResolver,
+  Mem0DeleteParams,
+  Mem0Message,
+  Mem0SearchParams,
+  Mem0SearchResult,
+} from "./memory-mem0.js";
+export {
+  DefaultMem0ContextResolver,
+  Mem0MemoryClient,
+} from "./memory-mem0.js";
+export type {
   MemoryConflict,
   MemoryConflictListOptions,
   MemoryConflictResolutionAction,


### PR DESCRIPTION
## Summary
- export Mem0 compatibility layer APIs from `@laup/core` public index
- add focused tests for Mem0 add/search/delete behavior and resolver mapping usage
- add an index export test to ensure Mem0 classes are publicly accessible

Closes #43

## Validation
- `pnpm test:run packages/core/src/__tests__/memory-mem0.test.ts packages/core/src/__tests__/index.test.ts` ✅
- `pnpm lint` ⚠️ fails due pre-existing Biome violations in unrelated files
- `pnpm --filter @laup/core typecheck` ⚠️ fails due pre-existing `memory-store.ts` type errors on main
- `pnpm test:run` ⚠️ fails due pre-existing `memory-store` suite failures on main
