### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/packages/config-hub/src/api-server.ts
+++ b/packages/config-hub/src/api-server.ts
@@ -67,7 +67,11 @@ export class ConfigApiServer {
         });
       if (error instanceof SyntaxError)
         return this.respond(res, 400, { error: { code: "INVALID_JSON", message: error.message } });
-      return this.respond(res, 500, { error: { code: "INTERNAL_ERROR", message: String(error) } });
+      // Log unexpected errors on the server, but do not expose details to the client.
+      console.error("Unhandled error in ConfigApiServer.handle:", error);
+      return this.respond(res, 500, {
+        error: { code: "INTERNAL_ERROR", message: "Internal server error" },
+      });
     }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/otterammo/laup/security/code-scanning/7](https://github.com/otterammo/laup/security/code-scanning/7)

In general, to fix this type of issue you should stop sending raw error information (messages, stacks, or full objects) back to the client for unexpected errors, and instead send a generic error message while logging the full error on the server for debugging.

For this specific code, the minimal change that keeps existing functionality is:

- In the generic `catch` branch (for errors that are not `ScopeCrudError` or `SyntaxError`), log the actual `error` on the server (e.g., with `console.error`).
- Change the HTTP 500 response so that it contains a generic, static message such as `"Internal server error"` rather than `String(error)`.
- Keep the `ScopeCrudError` and `SyntaxError` handling as-is, as those are clearly controlled, deliberate API errors.

Concretely, in `packages/config-hub/src/api-server.ts`:

- Update the `catch` block in `handle` to insert a `console.error` for unexpected errors before responding.
- Modify the `INTERNAL_ERROR` response so `message` is a constant (e.g., `"Internal server error"`) and does not use `String(error)`.

No new types or imports are required; `console.error` is available globally in Node.js.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
