### PR TITLE
feat(core): support Zep session memory integration patterns (MEM-006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ See [docs/memory-semantic-retrieval.md](docs/memory-semantic-retrieval.md) for M
 semantic retrieval behavior and API usage.
 See [docs/memory-scopes.md](docs/memory-scopes.md) for MEM-001 and MEM-012 memory scope and
 audit trail behavior.
+See [docs/zep-compatibility.md](docs/zep-compatibility.md) for MEM-006 Zep-compatible
+session memory integration patterns.
 See [docs/context-packet-format.md](docs/context-packet-format.md) for HAND-001
 standard context packet format requirements.
 

--- a/docs/zep-compatibility.md
+++ b/docs/zep-compatibility.md
@@ -1,0 +1,52 @@
+# Zep Compatibility Layer (MEM-006)
+
+LAUP provides a Zep-style integration facade in `packages/core/src/memory-zep.ts`.
+
+## What is compatible
+
+- Session-based memory model via `memory.session("...")`
+- `add_memory(...)`
+- `search_memory(...)`
+- `get_memory(...)`
+
+## Usage
+
+```ts
+import {
+  DefaultZepContextResolver,
+  InMemoryMemoryStore,
+  ZepMemoryClient,
+} from "@laup/core";
+
+const store = new InMemoryMemoryStore();
+await store.init();
+
+const memory = new ZepMemoryClient(
+  store,
+  new DefaultZepContextResolver({
+    orgId: "org-default",
+    projectId: "project-default",
+  }),
+);
+
+const session = memory.session("session-1");
+
+await session.add_memory("User likes concise release notes", {
+  topic: "preferences",
+});
+
+const results = await session.search_memory("release notes", { limit: 5 });
+
+const one = await session.get_memory(results[0]?.uuid);
+```
+
+## Context mapping
+
+By default, Zep session IDs map to LAUP context as:
+
+- `session_id` -> `sessionId`
+- `projectId` -> resolver default (`"zep"` if not set)
+- `orgId` -> resolver default
+
+Default scope is `session`, which keeps memories isolated per session.
+You can override scope through `DefaultZepContextResolver`.

--- a/packages/core/src/__tests__/memory-zep.test.ts
+++ b/packages/core/src/__tests__/memory-zep.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryMemoryStore, type MemoryStore } from "../memory-store.js";
+import { DefaultZepContextResolver, ZepMemoryClient } from "../memory-zep.js";
+
+describe("ZepMemoryClient", () => {
+  it("supports session model via bound session client", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new ZepMemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultZepContextResolver({ orgId: "org-1", projectId: "project-1" }),
+    );
+
+    const session = client.session("session-1");
+    const added = await session.add_memory("Remember onboarding checklist", { topic: "ops" });
+
+    expect(added).toHaveLength(1);
+    expect(added[0]?.content).toBe("Remember onboarding checklist");
+    expect(added[0]?.metadata).toMatchObject({ source: "zep", role: "user", topic: "ops" });
+
+    const memories = await session.get_memory();
+    expect(Array.isArray(memories)).toBe(true);
+    expect(memories).toHaveLength(1);
+  });
+
+  it("supports add_memory/search_memory/get_memory signatures", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new ZepMemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultZepContextResolver({ orgId: "org-1", projectId: "project-1" }),
+    );
+
+    const added = await client.add_memory({
+      session_id: "session-2",
+      memory: [
+        { role: "user", content: "Deploy service after smoke tests", metadata: { env: "prod" } },
+        { role: "assistant", content: "Rollback playbook is updated", metadata: { env: "prod" } },
+      ],
+      metadata: { app: "chat" },
+    });
+
+    expect(added).toHaveLength(2);
+
+    const searchResults = await client.search_memory({
+      session_id: "session-2",
+      query: "deploy smoke",
+      filters: { env: "prod" },
+      limit: 1,
+    });
+
+    expect(searchResults).toHaveLength(1);
+    expect(searchResults[0]?.content).toContain("Deploy");
+    expect(searchResults[0]?.score).toBeGreaterThan(0);
+
+    const firstAdded = added[0];
+    expect(firstAdded).toBeDefined();
+
+    const one = await client.get_memory({
+      session_id: "session-2",
+      memory_id: firstAdded?.uuid ?? "",
+    });
+
+    expect(one).not.toBeNull();
+    expect(Array.isArray(one)).toBe(false);
+    expect((one as { uuid: string }).uuid).toBe(firstAdded?.uuid);
+  });
+
+  it("isolates memories by session id", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new ZepMemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultZepContextResolver({ orgId: "org-1", projectId: "project-1" }),
+    );
+
+    await client.add_memory({
+      session_id: "session-a",
+      memory: "Session A memory",
+    });
+
+    await client.add_memory({
+      session_id: "session-b",
+      memory: "Session B memory",
+    });
+
+    const aMemories = await client.get_memory({ session_id: "session-a" });
+    const bMemories = await client.get_memory({ session_id: "session-b" });
+
+    expect(aMemories).toHaveLength(1);
+    expect((aMemories as { content: string }[])[0]?.content).toBe("Session A memory");
+    expect(bMemories).toHaveLength(1);
+    expect((bMemories as { content: string }[])[0]?.content).toBe("Session B memory");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -325,6 +325,20 @@ export {
   MemoryConflictError,
   SqlMemoryStore,
 } from "./memory-store.js";
+export type {
+  ZepAddMemoryParams,
+  ZepCompatibleMemoryClient,
+  ZepContextResolver,
+  ZepGetMemoryParams,
+  ZepMemory,
+  ZepMessage,
+  ZepSearchMemoryParams,
+  ZepSessionMemoryClient,
+} from "./memory-zep.js";
+export {
+  DefaultZepContextResolver,
+  ZepMemoryClient,
+} from "./memory-zep.js";
 export type { FieldIssue } from "./parse.js";
 export { ParseError, parseCanonical, parseCanonicalString } from "./parse.js";
 export type {

--- a/packages/core/src/memory-zep.ts
+++ b/packages/core/src/memory-zep.ts
@@ -1,0 +1,266 @@
+import type { MemoryContext, MemoryRecord, MemoryScope, MemoryStore } from "./memory-store.js";
+
+export interface ZepMessage {
+  role: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ZepMemory {
+  uuid: string;
+  content: string;
+  role: string;
+  metadata?: Record<string, unknown>;
+  created_at: string;
+  score?: number;
+}
+
+export interface ZepAddMemoryParams {
+  session_id: string;
+  memory: string | ZepMessage | ZepMessage[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ZepSearchMemoryParams {
+  session_id: string;
+  query: string;
+  limit?: number;
+  filters?: Record<string, unknown>;
+}
+
+export interface ZepGetMemoryParams {
+  session_id: string;
+  memory_id?: string;
+  limit?: number;
+}
+
+export interface ZepContextResolver {
+  resolve(params: { session_id: string }): {
+    context: MemoryContext;
+    scope: MemoryScope;
+  };
+}
+
+export interface ZepSessionMemoryClient {
+  add_memory(
+    memory: string | ZepMessage | ZepMessage[],
+    metadata?: Record<string, unknown>,
+  ): Promise<ZepMemory[]>;
+  search_memory(
+    query: string,
+    options?: { limit?: number; filters?: Record<string, unknown> },
+  ): Promise<ZepMemory[]>;
+  get_memory(memory_id?: string): Promise<ZepMemory[] | ZepMemory | null>;
+}
+
+export interface ZepCompatibleMemoryClient {
+  session(sessionId: string): ZepSessionMemoryClient;
+  add_memory(params: ZepAddMemoryParams): Promise<ZepMemory[]>;
+  search_memory(params: ZepSearchMemoryParams): Promise<ZepMemory[]>;
+  get_memory(params: ZepGetMemoryParams): Promise<ZepMemory[] | ZepMemory | null>;
+}
+
+export class DefaultZepContextResolver implements ZepContextResolver {
+  constructor(
+    private readonly defaults: {
+      orgId: string;
+      projectId?: string;
+      scope?: MemoryScope;
+    },
+  ) {}
+
+  resolve(params: { session_id: string }): {
+    context: MemoryContext;
+    scope: MemoryScope;
+  } {
+    const scope = this.defaults.scope ?? "session";
+    const projectId = this.defaults.projectId ?? "zep";
+
+    if (scope === "session") {
+      return {
+        context: {
+          orgId: this.defaults.orgId,
+          projectId,
+          sessionId: params.session_id,
+        },
+        scope,
+      };
+    }
+
+    if (scope === "project") {
+      return {
+        context: {
+          orgId: this.defaults.orgId,
+          projectId,
+        },
+        scope,
+      };
+    }
+
+    return {
+      context: {
+        orgId: this.defaults.orgId,
+      },
+      scope,
+    };
+  }
+}
+
+class BoundZepSessionMemoryClient implements ZepSessionMemoryClient {
+  constructor(
+    private readonly client: ZepMemoryClient,
+    private readonly sessionId: string,
+  ) {}
+
+  add_memory(
+    memory: string | ZepMessage | ZepMessage[],
+    metadata?: Record<string, unknown>,
+  ): Promise<ZepMemory[]> {
+    return this.client.add_memory({
+      session_id: this.sessionId,
+      memory,
+      ...(metadata ? { metadata } : {}),
+    });
+  }
+
+  search_memory(
+    query: string,
+    options?: { limit?: number; filters?: Record<string, unknown> },
+  ): Promise<ZepMemory[]> {
+    return this.client.search_memory({
+      session_id: this.sessionId,
+      query,
+      ...(options?.limit ? { limit: options.limit } : {}),
+      ...(options?.filters ? { filters: options.filters } : {}),
+    });
+  }
+
+  get_memory(memory_id?: string): Promise<ZepMemory[] | ZepMemory | null> {
+    return this.client.get_memory({
+      session_id: this.sessionId,
+      ...(memory_id ? { memory_id } : {}),
+    });
+  }
+}
+
+export class ZepMemoryClient implements ZepCompatibleMemoryClient {
+  constructor(
+    private readonly store: MemoryStore,
+    private readonly resolver: ZepContextResolver,
+  ) {}
+
+  session(sessionId: string): ZepSessionMemoryClient {
+    return new BoundZepSessionMemoryClient(this, sessionId);
+  }
+
+  async add_memory(params: ZepAddMemoryParams): Promise<ZepMemory[]> {
+    const normalized = this.normalizeMemory(params.memory);
+    const { context, scope } = this.resolver.resolve({ session_id: params.session_id });
+
+    const writes = normalized.map((entry) =>
+      this.store.write({
+        content: entry.content,
+        scope,
+        context,
+        sourceToolId: "zep",
+        metadata: {
+          source: "zep",
+          role: entry.role,
+          ...(entry.metadata ? entry.metadata : {}),
+          ...(params.metadata ? params.metadata : {}),
+        },
+      }),
+    );
+
+    const records = await Promise.all(writes);
+    return records.map((record) => this.toZepMemory(record));
+  }
+
+  async search_memory(params: ZepSearchMemoryParams): Promise<ZepMemory[]> {
+    const { context, scope } = this.resolver.resolve({ session_id: params.session_id });
+    const records = await this.store.listByScope(scope, context, {
+      includeSharedFromBroaderScopes: true,
+    });
+
+    return records
+      .map((record) => ({ record, score: this.score(record, params.query) }))
+      .filter((item) => item.score > 0)
+      .filter((item) => this.matchesFilters(item.record, params.filters))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, params.limit ?? 10)
+      .map((item) => this.toZepMemory(item.record, item.score));
+  }
+
+  async get_memory(params: ZepGetMemoryParams): Promise<ZepMemory[] | ZepMemory | null> {
+    const { context, scope } = this.resolver.resolve({ session_id: params.session_id });
+
+    if (params.memory_id) {
+      const record = await this.store.getById(params.memory_id, context);
+      if (!record || record.scope !== scope) {
+        return null;
+      }
+      return this.toZepMemory(record);
+    }
+
+    const records = await this.store.listByScope(scope, context, {
+      includeSharedFromBroaderScopes: true,
+    });
+    const sorted = records.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return sorted.slice(0, params.limit ?? 50).map((record) => this.toZepMemory(record));
+  }
+
+  private normalizeMemory(memory: string | ZepMessage | ZepMessage[]): ZepMessage[] {
+    if (typeof memory === "string") {
+      return [{ role: "user", content: memory }];
+    }
+
+    if (Array.isArray(memory)) {
+      return memory.filter((message) => message.content.trim().length > 0);
+    }
+
+    return memory.content.trim().length > 0 ? [memory] : [];
+  }
+
+  private toZepMemory(record: MemoryRecord, score?: number): ZepMemory {
+    const roleValue = record.metadata?.["role"];
+
+    return {
+      uuid: record.id,
+      content: record.content,
+      role: typeof roleValue === "string" ? roleValue : "user",
+      ...(record.metadata ? { metadata: record.metadata } : {}),
+      created_at: record.createdAt,
+      ...(typeof score === "number" ? { score } : {}),
+    };
+  }
+
+  private score(record: MemoryRecord, query: string): number {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return 0;
+
+    const haystack = [record.content, record.key ?? "", JSON.stringify(record.metadata ?? {})]
+      .join("\n")
+      .toLowerCase();
+
+    if (haystack === needle) return 1;
+    if (haystack.includes(needle)) return 0.8;
+
+    const tokens = needle.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return 0;
+
+    const hits = tokens.filter((token) => haystack.includes(token)).length;
+    return hits > 0 ? hits / tokens.length : 0;
+  }
+
+  private matchesFilters(record: MemoryRecord, filters?: Record<string, unknown>): boolean {
+    if (!filters) return true;
+
+    for (const [key, value] of Object.entries(filters)) {
+      if (record.metadata?.[key] !== value) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary\n- add Zep-compatible session memory client API for LAUP memory store\n- support session model with add_memory, search_memory, and get_memory patterns\n- export client/types from core index\n- add tests and docs for integration behavior\n\n## Validation\n- pnpm --filter @laup/core run typecheck\n- pnpm run test:run -- packages/core/src/__tests__/memory-zep.test.ts\n\nCloses #44