### PR TITLE
feat(core): support cross-tool context sharing within scope (MEM-004)

### DIFF
--- a/docs/memory-scopes.md
+++ b/docs/memory-scopes.md
@@ -29,6 +29,18 @@ Broader-scope visibility must be explicit via `includeSharedFromBroaderScopes: t
 
 No implicit cross-org, cross-project, or cross-session leakage is allowed.
 
+## Cross-tool Context Sharing (MEM-004)
+
+Memory entries are shared across tools within the same scope context (`org`, `project`,
+`session`) as soon as they are written.
+
+- Every entry records a `sourceToolId` (defaults to `"unknown"` if omitted)
+- Reads can optionally pass `requestingToolId` via `MemoryReadOptions`
+- Cross-tool reads are audit-visible via metadata fields:
+  - `requestingToolId`
+  - `sourceToolId`
+  - `crossToolRead` (`true` when reader and writer tool ids differ)
+
 ## Immutability
 
 Memory scope is write-time immutable.

--- a/packages/core/src/__tests__/memory-store.test.ts
+++ b/packages/core/src/__tests__/memory-store.test.ts
@@ -289,6 +289,58 @@ describe("memory-store", () => {
     ).rejects.toThrow(/different scope|already in use|unique/i);
   });
 
+  it("supports cross-tool reads in the same scope and audits them", async () => {
+    const auditStorage = new InMemoryAuditStorage();
+    await auditStorage.init();
+
+    const crossToolStore = new InMemoryMemoryStore({
+      auditStorage,
+      auditActor: "tester",
+    });
+    await crossToolStore.init();
+
+    await crossToolStore.write({
+      id: "cross-tool-memory",
+      content: "Shared deployment context",
+      scope: "project",
+      context,
+      sourceToolId: "claude-code",
+    });
+
+    const readByCursor = await crossToolStore.listByScope("project", context, {
+      requestingToolId: "cursor",
+    });
+
+    expect(readByCursor).toHaveLength(1);
+    expect(readByCursor[0]?.sourceToolId).toBe("claude-code");
+
+    await crossToolStore.getById("cross-tool-memory", context, {
+      requestingToolId: "cursor",
+    });
+
+    const page = await auditStorage.query({ category: "memory", actor: "tester" }, 100, 0);
+    const crossToolAudit = page.entries.find(
+      (entry) =>
+        entry.action === "memory.getById" &&
+        (entry.metadata?.["crossToolRead"] as boolean | undefined) === true,
+    );
+
+    expect(crossToolAudit).toBeDefined();
+    expect(crossToolAudit?.metadata?.["requestingToolId"]).toBe("cursor");
+    expect(crossToolAudit?.metadata?.["sourceToolId"]).toBe("claude-code");
+  });
+
+  it("defaults sourceToolId to unknown when omitted", async () => {
+    const record = await store.write({
+      id: "unknown-source",
+      content: "no source provided",
+      scope: "project",
+      context,
+    });
+
+    expect(record.sourceToolId).toBe("unknown");
+  });
+
   it("records an audit trail for memory operations", async () => {
     const auditStorage = new InMemoryAuditStorage();
     await auditStorage.init();
@@ -332,39 +384,5 @@ describe("memory-store", () => {
     expect(actions).toContain("memory.getByKey");
     expect(actions).toContain("memory.pruneExpired");
     expect(actions).toContain("memory.conflict");
-  });
-
-  it("records an audit trail for memory operations", async () => {
-    const auditStorage = new InMemoryAuditStorage();
-    await auditStorage.init();
-
-    const auditedStore = new InMemoryMemoryStore({
-      auditStorage,
-      auditActor: "tester",
-    });
-    await auditedStore.init();
-
-    await auditedStore.write({
-      id: "audited-memory",
-      key: "checklist",
-      content: "Run post-deploy smoke checks",
-      scope: "project",
-      context,
-    });
-
-    await auditedStore.listByScope("project", context);
-    await auditedStore.getById("audited-memory", context);
-    await auditedStore.getByKey("checklist", context);
-    await auditedStore.pruneExpired(new Date("2030-01-01T00:00:00.000Z"));
-
-    const page = await auditStorage.query({ category: "memory", actor: "tester" }, 50, 0);
-    const actions = page.entries.map((entry) => entry.action);
-
-    expect(actions).toContain("memory.init");
-    expect(actions).toContain("memory.write");
-    expect(actions).toContain("memory.listByScope");
-    expect(actions).toContain("memory.getById");
-    expect(actions).toContain("memory.getByKey");
-    expect(actions).toContain("memory.pruneExpired");
   });
 });

--- a/packages/core/src/memory-store.ts
+++ b/packages/core/src/memory-store.ts
@@ -74,6 +74,7 @@ export type MemoryConflictResolutionAction = "accept-incoming" | "keep-existing"
 
 export interface MemoryReadOptions {
   includeSharedFromBroaderScopes?: boolean;
+  requestingToolId?: string;
   now?: Date;
 }
 
@@ -307,6 +308,7 @@ export class InMemoryMemoryStore implements MemoryStore {
       this.conflictResolutionByProject?.(input.context) ?? this.conflictResolutionStrategy;
 
     const scopeContext = buildScopeContext(input.scope, input.context);
+    const sourceToolId = input.sourceToolId ?? "unknown";
 
     let id = requestedId;
     let existing = this.records.get(id);
@@ -387,7 +389,7 @@ export class InMemoryMemoryStore implements MemoryStore {
       ...scopeContext,
       ...(expiresAt ? { expiresAt } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
-      ...(input.sourceToolId ? { sourceToolId: input.sourceToolId } : {}),
+      sourceToolId,
     };
 
     if (existing?.key && existing.key !== nextKey) {
@@ -407,6 +409,7 @@ export class InMemoryMemoryStore implements MemoryStore {
         projectId: scopeContext.projectId,
         sessionId: scopeContext.sessionId,
         key: nextKey,
+        sourceToolId,
       },
     });
 
@@ -426,6 +429,7 @@ export class InMemoryMemoryStore implements MemoryStore {
   ): Promise<MemoryRecord[]> {
     const now = options?.now ?? new Date();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+    const requestingToolId = options?.requestingToolId;
 
     const records = Array.from(this.records.values())
       .filter((record) => !isExpired(record, now))
@@ -440,6 +444,7 @@ export class InMemoryMemoryStore implements MemoryStore {
         projectId: context.projectId,
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
+        requestingToolId,
         resultCount: records.length,
       },
     });
@@ -454,6 +459,7 @@ export class InMemoryMemoryStore implements MemoryStore {
   ): Promise<MemoryRecord | null> {
     const now = options?.now ?? new Date();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+    const requestingToolId = options?.requestingToolId;
     const record = this.records.get(id);
     if (!record || isExpired(record, now)) {
       await this.auditLogger.record({
@@ -479,6 +485,11 @@ export class InMemoryMemoryStore implements MemoryStore {
         projectId: context.projectId,
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
+        requestingToolId,
+        sourceToolId: record.sourceToolId,
+        crossToolRead: Boolean(
+          result && requestingToolId && record.sourceToolId !== requestingToolId,
+        ),
       },
     });
 
@@ -490,6 +501,7 @@ export class InMemoryMemoryStore implements MemoryStore {
     context: MemoryContext,
     options?: MemoryReadOptions,
   ): Promise<MemoryRecord | null> {
+    const requestingToolId = options?.requestingToolId;
     const sessionContext: Pick<MemoryRecord, "orgId" | "projectId" | "sessionId"> = {
       orgId: context.orgId,
       ...(context.projectId ? { projectId: context.projectId } : {}),
@@ -509,7 +521,17 @@ export class InMemoryMemoryStore implements MemoryStore {
       await this.auditLogger.record({
         action: "memory.getByKey",
         ...(result?.id ? { targetId: result.id } : {}),
-        metadata: { key, orgId: context.orgId, found: Boolean(result), scope: "session" },
+        metadata: {
+          key,
+          orgId: context.orgId,
+          found: Boolean(result),
+          scope: "session",
+          requestingToolId,
+          sourceToolId: result?.sourceToolId,
+          crossToolRead: Boolean(
+            result && requestingToolId && result.sourceToolId !== requestingToolId,
+          ),
+        },
       });
       return result;
     }
@@ -520,7 +542,17 @@ export class InMemoryMemoryStore implements MemoryStore {
       await this.auditLogger.record({
         action: "memory.getByKey",
         ...(result?.id ? { targetId: result.id } : {}),
-        metadata: { key, orgId: context.orgId, found: Boolean(result), scope: "project" },
+        metadata: {
+          key,
+          orgId: context.orgId,
+          found: Boolean(result),
+          scope: "project",
+          requestingToolId,
+          sourceToolId: result?.sourceToolId,
+          crossToolRead: Boolean(
+            result && requestingToolId && result.sourceToolId !== requestingToolId,
+          ),
+        },
       });
       return result;
     }
@@ -531,7 +563,17 @@ export class InMemoryMemoryStore implements MemoryStore {
       await this.auditLogger.record({
         action: "memory.getByKey",
         ...(result?.id ? { targetId: result.id } : {}),
-        metadata: { key, orgId: context.orgId, found: Boolean(result), scope: "org" },
+        metadata: {
+          key,
+          orgId: context.orgId,
+          found: Boolean(result),
+          scope: "org",
+          requestingToolId,
+          sourceToolId: result?.sourceToolId,
+          crossToolRead: Boolean(
+            result && requestingToolId && result.sourceToolId !== requestingToolId,
+          ),
+        },
       });
       return result;
     }
@@ -763,6 +805,7 @@ export class SqlMemoryStore implements MemoryStore {
     }
 
     const scopeContext = buildScopeContext(input.scope, input.context);
+    const sourceToolId = input.sourceToolId ?? "unknown";
     const expiresAt =
       input.scope === "session" ? new Date(now.getTime() + SESSION_TTL_MS).toISOString() : null;
     const createdAt = existing?.created_at ?? now.toISOString();
@@ -838,7 +881,7 @@ export class SqlMemoryStore implements MemoryStore {
         scopeContext.projectId ?? null,
         scopeContext.sessionId ?? null,
         input.metadata ? JSON.stringify(input.metadata) : null,
-        input.sourceToolId ?? null,
+        sourceToolId,
         JSON.stringify(embedding),
         embeddingModel,
         createdAt,
@@ -857,7 +900,7 @@ export class SqlMemoryStore implements MemoryStore {
       createdAt,
       ...(expiresAt ? { expiresAt } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
-      ...(input.sourceToolId ? { sourceToolId: input.sourceToolId } : {}),
+      sourceToolId,
       embedding,
       embeddingModel,
     };
@@ -871,6 +914,7 @@ export class SqlMemoryStore implements MemoryStore {
         projectId: scopeContext.projectId,
         sessionId: scopeContext.sessionId,
         key,
+        sourceToolId,
       },
     });
 
@@ -890,6 +934,7 @@ export class SqlMemoryStore implements MemoryStore {
   ): Promise<MemoryRecord[]> {
     const now = (options?.now ?? new Date()).toISOString();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+    const requestingToolId = options?.requestingToolId;
 
     const allowedScopes: MemoryScope[] = includeShared
       ? scope === "session"
@@ -933,6 +978,7 @@ export class SqlMemoryStore implements MemoryStore {
         projectId: context.projectId,
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
+        requestingToolId,
         resultCount: records.length,
       },
     });
@@ -947,6 +993,7 @@ export class SqlMemoryStore implements MemoryStore {
   ): Promise<MemoryRecord | null> {
     const now = options?.now ?? new Date();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+    const requestingToolId = options?.requestingToolId;
 
     const row = await this.db.queryOne<MemoryRow>(
       `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at
@@ -990,6 +1037,11 @@ export class SqlMemoryStore implements MemoryStore {
         projectId: context.projectId,
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
+        requestingToolId,
+        sourceToolId: record.sourceToolId,
+        crossToolRead: Boolean(
+          visibleRecord && requestingToolId && record.sourceToolId !== requestingToolId,
+        ),
       },
     });
 
@@ -1003,6 +1055,7 @@ export class SqlMemoryStore implements MemoryStore {
   ): Promise<MemoryRecord | null> {
     const now = options?.now ?? new Date();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
+    const requestingToolId = options?.requestingToolId;
 
     const row = await this.db.queryOne<MemoryRow>(
       `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at
@@ -1066,6 +1119,11 @@ export class SqlMemoryStore implements MemoryStore {
         orgId: context.orgId,
         found: Boolean(visibleRecord),
         includeSharedFromBroaderScopes: includeShared,
+        requestingToolId,
+        sourceToolId: record.sourceToolId,
+        crossToolRead: Boolean(
+          visibleRecord && requestingToolId && record.sourceToolId !== requestingToolId,
+        ),
       },
     });
 
@@ -1238,7 +1296,7 @@ export class SqlMemoryStore implements MemoryStore {
       createdAt: String(row.created_at),
       ...(row.expires_at ? { expiresAt: String(row.expires_at) } : {}),
       ...(metadata ? { metadata } : {}),
-      ...(row.source_tool_id ? { sourceToolId: String(row.source_tool_id) } : {}),
+      sourceToolId: row.source_tool_id ? String(row.source_tool_id) : "unknown",
       ...(embedding ? { embedding } : {}),
       ...(row.embedding_model ? { embeddingModel: String(row.embedding_model) } : {}),
     };


### PR DESCRIPTION
## Summary
- implement MEM-004 cross-tool memory sharing behaviors in the core memory store
- ensure every memory record carries `sourceToolId` (defaults to `unknown`)
- add optional `requestingToolId` read option and audit metadata for cross-tool reads (`crossToolRead`, source/requesting tool ids)
- add focused unit coverage for cross-tool visibility + auditing and source defaulting
- document the MEM-004 behavior in memory scope docs

## Validation
- `pnpm vitest packages/core/src/__tests__/memory-store.test.ts packages/core/src/__tests__/memory-store.semantic.test.ts packages/core/src/__tests__/memory-mem0.test.ts`
- `pnpm --filter @laup/core build`

Closes #42
