### PR TITLE
feat(memory): support memory tagging and categorization filters (MEM-008)

### DIFF
--- a/docs/memory-semantic-retrieval.md
+++ b/docs/memory-semantic-retrieval.md
@@ -8,6 +8,7 @@
 - Embedding model is configurable (`defaultEmbeddingModel` + per-write override)
 - Retrieval ranks results by cosine similarity
 - Top-K results are supported (`k`, default `10`)
+- Optional filtered retrieval by memory `tags` and `category`
 
 ## API
 
@@ -15,7 +16,7 @@ See `packages/core/src/memory-store.ts`:
 
 - `MemoryEmbeddingProvider`
 - `MemoryStore#semanticSearch(query, scope, context, options)`
-- `MemorySearchOptions` (`k`, `embeddingModel`, scope visibility options)
+- `MemorySearchOptions` (`k`, `embeddingModel`, scope visibility options, retrieval `filter`)
 - `MemorySearchResult` (`memory`, `score`)
 
 ## Example
@@ -35,12 +36,14 @@ await store.write({
   content: "Postmortem: DB migration lock contention on deploy",
   scope: "project",
   context: { orgId: "org-1", projectId: "proj-1" },
+  tags: ["incident", "database"],
+  category: "postmortem",
 });
 
 const hits = await store.semanticSearch(
   "what happened during database deploy incident?",
   "project",
   { orgId: "org-1", projectId: "proj-1" },
-  { k: 5 },
+  { k: 5, filter: { tags: ["incident"], categories: ["postmortem"] } },
 );
 ```

--- a/packages/core/src/__tests__/memory-mem0.test.ts
+++ b/packages/core/src/__tests__/memory-mem0.test.ts
@@ -68,6 +68,34 @@ describe("Mem0MemoryClient", () => {
     expect(results[0]?.score).toBeGreaterThan(0);
   });
 
+  it("supports category/tags filters for retrieval", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new Mem0MemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultMem0ContextResolver({ orgId: "org-default" }),
+    );
+
+    await client.add("Deploy release note", {
+      user_id: "org-1",
+      metadata: { env: "prod", tags: ["release", "ops"], category: "runbook" },
+    });
+    await client.add("Personal todo", {
+      user_id: "org-1",
+      metadata: { env: "prod", tags: ["personal"], category: "notes" },
+    });
+
+    const results = await client.search({
+      query: "deploy",
+      user_id: "org-1",
+      filters: { category: "runbook", tags: ["release"] },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.memory).toContain("Deploy");
+  });
+
   it("deletes memories by id with either string id or params object", async () => {
     const store = new InMemoryMemoryStore();
     await store.init();

--- a/packages/core/src/__tests__/memory-store.semantic.test.ts
+++ b/packages/core/src/__tests__/memory-store.semantic.test.ts
@@ -80,6 +80,51 @@ describe("memory-store semantic retrieval", () => {
     expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0);
   });
 
+  it("supports filtered retrieval by tags and category", async () => {
+    const provider = new KeywordEmbeddingProvider(["deploy", "incident", "travel"]);
+    const store = createSemanticMemoryStore({ embeddingProvider: provider });
+
+    await store.writeBatch([
+      {
+        id: "m1",
+        content: "Deploy the release candidate",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        tags: ["release", "ops"],
+        category: "runbook",
+      },
+      {
+        id: "m2",
+        content: "Incident retrospective and remediation",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        tags: ["incident"],
+        category: "postmortem",
+      },
+      {
+        id: "m3",
+        content: "Travel planning notes",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        tags: ["personal"],
+        category: "notes",
+      },
+    ]);
+
+    const filtered = await store.semanticSearch("deploy", "project", PROJECT_CONTEXT, {
+      k: 10,
+      filter: { tags: ["release"], categories: ["runbook"] },
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.memory.id).toBe("m1");
+
+    const byCategory = await store.listByScope("project", PROJECT_CONTEXT, {
+      filter: { categories: ["postmortem"] },
+    });
+    expect(byCategory.map((item) => item.id)).toEqual(["m2"]);
+  });
+
   it("uses configurable top-k with default=10", async () => {
     const provider = new KeywordEmbeddingProvider(["task"]);
     const store = createSemanticMemoryStore({ embeddingProvider: provider });

--- a/packages/core/src/__tests__/memory-zep.test.ts
+++ b/packages/core/src/__tests__/memory-zep.test.ts
@@ -118,6 +118,36 @@ describe("ZepMemoryClient", () => {
     expect(extracted[0]?.content).toContain("my timezone is America/Chicago");
   });
 
+  it("supports category and tags in filters", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const client = new ZepMemoryClient(
+      store as unknown as MemoryStore,
+      new DefaultZepContextResolver({ orgId: "org-1", projectId: "project-1" }),
+    );
+
+    await client.add_memory({
+      session_id: "session-filter",
+      memory: "Release deployment steps",
+      metadata: { category: "runbook", tags: ["release", "ops"] },
+    });
+    await client.add_memory({
+      session_id: "session-filter",
+      memory: "Weekend ideas",
+      metadata: { category: "notes", tags: ["personal"] },
+    });
+
+    const filtered = await client.search_memory({
+      session_id: "session-filter",
+      query: "release",
+      filters: { category: "runbook", tags: ["release"] },
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.content).toContain("Release");
+  });
+
   it("isolates memories by session id", async () => {
     const store = new InMemoryMemoryStore();
     await store.init();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,6 +310,7 @@ export type {
   MemoryEmbeddingProvider,
   MemoryReadOptions,
   MemoryRecord,
+  MemoryRetrievalFilter,
   MemoryScope,
   MemorySearchOptions,
   MemorySearchResult,

--- a/packages/core/src/memory-mem0.ts
+++ b/packages/core/src/memory-mem0.ts
@@ -92,12 +92,22 @@ export class Mem0MemoryClient implements Mem0CompatibleMemoryClient {
     });
 
     const resolvedScope = scope ?? this.pickScope(context);
+    const rawTags = params?.metadata?.["tags"];
+    const tags =
+      Array.isArray(rawTags) && rawTags.every((tag) => typeof tag === "string")
+        ? (rawTags as string[])
+        : undefined;
+    const rawCategory = params?.metadata?.["category"];
+    const category = typeof rawCategory === "string" ? rawCategory : undefined;
+
     const writes = normalized.map((message) =>
       this.store.write({
         content: message.content,
         scope: resolvedScope,
         context,
         sourceToolId: "mem0",
+        ...(tags ? { tags } : {}),
+        ...(category ? { category } : {}),
         metadata: {
           source: "mem0",
           role: message.role,
@@ -193,6 +203,17 @@ export class Mem0MemoryClient implements Mem0CompatibleMemoryClient {
   private matchesFilters(record: MemoryRecord, filters?: Record<string, unknown>): boolean {
     if (!filters) return true;
     for (const [key, value] of Object.entries(filters)) {
+      if (key === "category") {
+        if (record.category !== value) return false;
+        continue;
+      }
+      if (key === "tags") {
+        const wanted = Array.isArray(value) ? value : [value];
+        const tags = new Set(record.tags ?? []);
+        if (wanted.some((tag) => typeof tag !== "string" || !tags.has(tag))) return false;
+        continue;
+      }
+
       const metadataValue = record.metadata?.[key];
       if (metadataValue !== value) {
         return false;

--- a/packages/core/src/memory-store.ts
+++ b/packages/core/src/memory-store.ts
@@ -29,6 +29,8 @@ export interface MemoryRecord {
   createdAt: string;
   expiresAt?: string;
   metadata?: Record<string, unknown>;
+  tags?: string[];
+  category?: string;
   sourceToolId?: string;
   embedding?: number[];
   embeddingModel?: string;
@@ -41,6 +43,8 @@ export interface MemoryWriteInput {
   scope: MemoryScope;
   context: MemoryContext;
   metadata?: Record<string, unknown>;
+  tags?: string[];
+  category?: string;
   sourceToolId?: string;
   embeddingModel?: string;
   now?: Date;
@@ -72,10 +76,16 @@ export interface MemoryConflictListOptions {
 
 export type MemoryConflictResolutionAction = "accept-incoming" | "keep-existing";
 
+export interface MemoryRetrievalFilter {
+  tags?: string[];
+  categories?: string[];
+}
+
 export interface MemoryReadOptions {
   includeSharedFromBroaderScopes?: boolean;
   requestingToolId?: string;
   now?: Date;
+  filter?: MemoryRetrievalFilter;
 }
 
 export interface MemorySearchOptions {
@@ -83,6 +93,7 @@ export interface MemorySearchOptions {
   now?: Date;
   k?: number;
   embeddingModel?: string;
+  filter?: MemoryRetrievalFilter;
 }
 
 export interface MemorySearchResult {
@@ -158,6 +169,37 @@ function buildScopeContext(
 
 function isExpired(record: MemoryRecord, now: Date): boolean {
   return Boolean(record.expiresAt && new Date(record.expiresAt).getTime() <= now.getTime());
+}
+
+function normalizeTags(tags?: string[]): string[] | undefined {
+  if (!tags) return undefined;
+  const normalized = Array.from(
+    new Set(tags.map((tag) => tag.trim().toLowerCase()).filter(Boolean)),
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeCategory(category?: string): string | undefined {
+  const normalized = category?.trim().toLowerCase();
+  return normalized ? normalized : undefined;
+}
+
+function matchesFilter(record: MemoryRecord, filter?: MemoryRetrievalFilter): boolean {
+  if (!filter) return true;
+
+  const recordTags = new Set(record.tags ?? []);
+  const requiredTags = normalizeTags(filter.tags) ?? [];
+  if (requiredTags.some((tag) => !recordTags.has(tag))) {
+    return false;
+  }
+
+  const categories = normalizeTags(filter.categories);
+  if (categories && categories.length > 0) {
+    const recordCategory = normalizeCategory(record.category);
+    if (!recordCategory || !categories.includes(recordCategory)) return false;
+  }
+
+  return true;
 }
 
 function canRead(
@@ -377,6 +419,8 @@ export class InMemoryMemoryStore implements MemoryStore {
 
     const embeddingModel = input.embeddingModel ?? this.defaultEmbeddingModel;
     const embedding = await this.embeddingProvider.embed(input.content, { model: embeddingModel });
+    const tags = normalizeTags(input.tags ?? existing?.tags);
+    const category = normalizeCategory(input.category ?? existing?.category);
 
     const record: MemoryRecord = {
       id,
@@ -389,6 +433,8 @@ export class InMemoryMemoryStore implements MemoryStore {
       ...scopeContext,
       ...(expiresAt ? { expiresAt } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...(tags ? { tags } : {}),
+      ...(category ? { category } : {}),
       sourceToolId,
     };
 
@@ -409,6 +455,8 @@ export class InMemoryMemoryStore implements MemoryStore {
         projectId: scopeContext.projectId,
         sessionId: scopeContext.sessionId,
         key: nextKey,
+        tags,
+        category,
         sourceToolId,
       },
     });
@@ -430,10 +478,12 @@ export class InMemoryMemoryStore implements MemoryStore {
     const now = options?.now ?? new Date();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
     const requestingToolId = options?.requestingToolId;
+    const filter = options?.filter;
 
     const records = Array.from(this.records.values())
       .filter((record) => !isExpired(record, now))
       .filter((record) => canRead(record, scope, context, includeShared))
+      .filter((record) => matchesFilter(record, filter))
       .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
 
     await this.auditLogger.record({
@@ -445,6 +495,7 @@ export class InMemoryMemoryStore implements MemoryStore {
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
         requestingToolId,
+        filter,
         resultCount: records.length,
       },
     });
@@ -656,11 +707,13 @@ export class InMemoryMemoryStore implements MemoryStore {
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
     const k = Math.max(1, options?.k ?? this.defaultTopK);
     const model = options?.embeddingModel ?? this.defaultEmbeddingModel;
+    const filter = options?.filter;
     const queryEmbedding = await this.embeddingProvider.embed(query, { model });
 
     return Array.from(this.records.values())
       .filter((record) => !isExpired(record, now))
       .filter((record) => canRead(record, scope, context, includeShared))
+      .filter((record) => matchesFilter(record, filter))
       .map((memory) => ({
         memory,
         score: cosineSimilarity(queryEmbedding, memory.embedding ?? []),
@@ -702,6 +755,8 @@ interface MemoryRow {
   project_id: string | null;
   session_id: string | null;
   metadata: string | null;
+  tags: string | null;
+  category: string | null;
   source_tool_id: string | null;
   embedding: string | null;
   embedding_model: string | null;
@@ -742,6 +797,8 @@ export class SqlMemoryStore implements MemoryStore {
         project_id TEXT,
         session_id TEXT,
         metadata TEXT,
+        tags TEXT,
+        category TEXT,
         source_tool_id TEXT,
         embedding TEXT,
         embedding_model TEXT,
@@ -766,6 +823,9 @@ export class SqlMemoryStore implements MemoryStore {
     await this.db.execute(
       `CREATE INDEX IF NOT EXISTS idx_memories_expires_at ON memories(expires_at)`,
     );
+
+    await this.ensureOptionalColumn("memories", "tags", "TEXT");
+    await this.ensureOptionalColumn("memories", "category", "TEXT");
 
     await this.db.execute(`
       CREATE TABLE IF NOT EXISTS memory_conflicts (
@@ -798,7 +858,9 @@ export class SqlMemoryStore implements MemoryStore {
       scope: string;
       created_at: string;
       key: string | null;
-    }>(`SELECT scope, created_at, key FROM memories WHERE id = ?`, [id]);
+      tags: string | null;
+      category: string | null;
+    }>(`SELECT scope, created_at, key, tags, category FROM memories WHERE id = ?`, [id]);
 
     if (existing && existing.scope !== input.scope) {
       throw new Error(`Memory scope is immutable for id ${id}`);
@@ -868,10 +930,14 @@ export class SqlMemoryStore implements MemoryStore {
 
     const embeddingModel = input.embeddingModel ?? this.defaultEmbeddingModel;
     const embedding = await this.embeddingProvider.embed(input.content, { model: embeddingModel });
+    const existingTags =
+      typeof existing?.tags === "string" ? (JSON.parse(existing.tags) as string[]) : undefined;
+    const tags = normalizeTags(input.tags ?? existingTags);
+    const category = normalizeCategory(input.category ?? existing?.category ?? undefined);
 
     await this.db.execute(
-      `INSERT OR REPLACE INTO memories (id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO memories (id, key, content, scope, org_id, project_id, session_id, metadata, tags, category, source_tool_id, embedding, embedding_model, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         key,
@@ -881,6 +947,8 @@ export class SqlMemoryStore implements MemoryStore {
         scopeContext.projectId ?? null,
         scopeContext.sessionId ?? null,
         input.metadata ? JSON.stringify(input.metadata) : null,
+        tags ? JSON.stringify(tags) : null,
+        category ?? null,
         sourceToolId,
         JSON.stringify(embedding),
         embeddingModel,
@@ -900,6 +968,8 @@ export class SqlMemoryStore implements MemoryStore {
       createdAt,
       ...(expiresAt ? { expiresAt } : {}),
       ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...(tags ? { tags } : {}),
+      ...(category ? { category } : {}),
       sourceToolId,
       embedding,
       embeddingModel,
@@ -914,6 +984,8 @@ export class SqlMemoryStore implements MemoryStore {
         projectId: scopeContext.projectId,
         sessionId: scopeContext.sessionId,
         key,
+        tags,
+        category,
         sourceToolId,
       },
     });
@@ -935,6 +1007,7 @@ export class SqlMemoryStore implements MemoryStore {
     const now = (options?.now ?? new Date()).toISOString();
     const includeShared = options?.includeSharedFromBroaderScopes ?? false;
     const requestingToolId = options?.requestingToolId;
+    const filter = options?.filter;
 
     const allowedScopes: MemoryScope[] = includeShared
       ? scope === "session"
@@ -948,7 +1021,7 @@ export class SqlMemoryStore implements MemoryStore {
     const params: (string | null)[] = [context.orgId, ...allowedScopes, now];
 
     let query = `
-      SELECT id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at
+      SELECT id, key, content, scope, org_id, project_id, session_id, metadata, tags, category, source_tool_id, embedding, embedding_model, created_at, expires_at
       FROM memories
       WHERE org_id = ?
         AND scope IN (${placeholders})
@@ -968,7 +1041,8 @@ export class SqlMemoryStore implements MemoryStore {
     const result = await this.db.query<MemoryRow>(query, params);
     const records = result.rows
       .map((row) => this.rowToRecord(row))
-      .filter((record) => canRead(record, scope, context, includeShared));
+      .filter((record) => canRead(record, scope, context, includeShared))
+      .filter((record) => matchesFilter(record, filter));
 
     await this.auditLogger.record({
       action: "memory.listByScope",
@@ -979,6 +1053,7 @@ export class SqlMemoryStore implements MemoryStore {
         sessionId: context.sessionId,
         includeSharedFromBroaderScopes: includeShared,
         requestingToolId,
+        filter,
         resultCount: records.length,
       },
     });
@@ -996,7 +1071,7 @@ export class SqlMemoryStore implements MemoryStore {
     const requestingToolId = options?.requestingToolId;
 
     const row = await this.db.queryOne<MemoryRow>(
-      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at
+      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, tags, category, source_tool_id, embedding, embedding_model, created_at, expires_at
        FROM memories
        WHERE id = ?`,
       [id],
@@ -1058,7 +1133,7 @@ export class SqlMemoryStore implements MemoryStore {
     const requestingToolId = options?.requestingToolId;
 
     const row = await this.db.queryOne<MemoryRow>(
-      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, source_tool_id, embedding, embedding_model, created_at, expires_at
+      `SELECT id, key, content, scope, org_id, project_id, session_id, metadata, tags, category, source_tool_id, embedding, embedding_model, created_at, expires_at
        FROM memories
        WHERE org_id = ?
          AND key = ?
@@ -1275,6 +1350,18 @@ export class SqlMemoryStore implements MemoryStore {
     return removed;
   }
 
+  private async ensureOptionalColumn(
+    table: string,
+    column: string,
+    columnType: string,
+  ): Promise<void> {
+    try {
+      await this.db.execute(`ALTER TABLE ${table} ADD COLUMN ${column} ${columnType}`);
+    } catch {
+      // Column likely already exists.
+    }
+  }
+
   private rowToRecord(row: MemoryRow): MemoryRecord {
     const metadataRaw = row.metadata;
     const metadata =
@@ -1284,6 +1371,8 @@ export class SqlMemoryStore implements MemoryStore {
 
     const embedding =
       typeof row.embedding === "string" ? (JSON.parse(row.embedding) as number[]) : undefined;
+    const tags = typeof row.tags === "string" ? (JSON.parse(row.tags) as string[]) : undefined;
+    const category = normalizeCategory(row.category ?? undefined);
 
     return {
       id: String(row.id),
@@ -1296,6 +1385,8 @@ export class SqlMemoryStore implements MemoryStore {
       createdAt: String(row.created_at),
       ...(row.expires_at ? { expiresAt: String(row.expires_at) } : {}),
       ...(metadata ? { metadata } : {}),
+      ...(tags ? { tags } : {}),
+      ...(category ? { category } : {}),
       sourceToolId: row.source_tool_id ? String(row.source_tool_id) : "unknown",
       ...(embedding ? { embedding } : {}),
       ...(row.embedding_model ? { embeddingModel: String(row.embedding_model) } : {}),

--- a/packages/core/src/memory-zep.ts
+++ b/packages/core/src/memory-zep.ts
@@ -180,6 +180,16 @@ export class ZepMemoryClient implements ZepCompatibleMemoryClient {
   async add_memory(params: ZepAddMemoryParams): Promise<ZepMemory[]> {
     const normalized = this.normalizeMemory(params.memory);
     const { context, scope } = this.resolver.resolve({ session_id: params.session_id });
+    const mergedMetadata = {
+      ...(params.metadata ? params.metadata : {}),
+    } as Record<string, unknown>;
+    const rawTags = mergedMetadata["tags"];
+    const tags =
+      Array.isArray(rawTags) && rawTags.every((tag) => typeof tag === "string")
+        ? (rawTags as string[])
+        : undefined;
+    const rawCategory = mergedMetadata["category"];
+    const category = typeof rawCategory === "string" ? rawCategory : undefined;
 
     const writes = normalized.map((entry) =>
       this.store.write({
@@ -187,6 +197,8 @@ export class ZepMemoryClient implements ZepCompatibleMemoryClient {
         scope,
         context,
         sourceToolId: "zep",
+        ...(tags ? { tags } : {}),
+        ...(category ? { category } : {}),
         metadata: {
           source: "zep",
           role: entry.role,
@@ -362,6 +374,17 @@ export class ZepMemoryClient implements ZepCompatibleMemoryClient {
     if (!filters) return true;
 
     for (const [key, value] of Object.entries(filters)) {
+      if (key === "category") {
+        if (record.category !== value) return false;
+        continue;
+      }
+      if (key === "tags") {
+        const wanted = Array.isArray(value) ? value : [value];
+        const tags = new Set(record.tags ?? []);
+        if (wanted.some((tag) => typeof tag !== "string" || !tags.has(tag))) return false;
+        continue;
+      }
+
       if (record.metadata?.[key] !== value) {
         return false;
       }


### PR DESCRIPTION
## Summary
- add first-class memory tags and category fields on records/writes
- add retrieval filters (`tags`, `categories`) for `listByScope` and `semanticSearch`
- propagate tag/category behavior through Mem0 and Zep compatibility clients
- add tests for filtered retrieval in core, Mem0, and Zep paths
- update semantic retrieval docs with tagging/category examples

Closes #46

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run`
- `pnpm lint` *(fails on pre-existing repo-wide Biome diagnostics on main; unchanged by this PR)*
