### PR TITLE
feat(core): implement HAND-003 context packet deserializers

### DIFF
--- a/packages/core/src/__tests__/context-packet-serializers.test.ts
+++ b/packages/core/src/__tests__/context-packet-serializers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  deserializeClaudeCodeContext,
+  deserializeCursorContext,
   serializeClaudeCodeContext,
   serializeCursorContext,
 } from "../context-packet-serializers.js";
@@ -146,5 +148,70 @@ describe("context-packet-serializers (HAND-002)", () => {
         },
       }
     `);
+  });
+
+  it("round-trips Claude Code native state and emits MEMORY.md prepend payload", () => {
+    const native = {
+      taskContext: {
+        taskId: "task-5",
+        objective: "Ship HAND-003",
+        status: "running" as const,
+        notes: "Hand off to Cursor next",
+      },
+      activeFiles: ["packages/core/src/context-packet-serializers.ts"],
+      memoryMd: "# Existing Memory\n- item",
+    };
+
+    const packet = serializeClaudeCodeContext({
+      id: "packet-claude-rt",
+      sourceAgent: "claude-code",
+      targetAgent: "cursor",
+      createdAt: "2026-03-04T23:10:00.000Z",
+      task: "Complete HAND-003",
+      native,
+    });
+
+    const restored = deserializeClaudeCodeContext(packet);
+
+    expect(restored.native).toEqual(native);
+    expect(restored.memoryWrite).toEqual({
+      filePath: "MEMORY.md",
+      mode: "prepend",
+      content: "## Handoff Summary\nComplete HAND-003\n\n# Existing Memory\n- item",
+    });
+  });
+
+  it("round-trips Cursor native state and emits notepad/file open actions", () => {
+    const native = {
+      notepads: [
+        {
+          id: "np-22",
+          title: "todo",
+          content: "Wire deserializers",
+        },
+      ],
+      editor: {
+        workspaceRoot: "/repo",
+        openFiles: ["src/a.ts", "src/b.ts"],
+        activeFile: "src/b.ts",
+      },
+    };
+
+    const packet = serializeCursorContext({
+      id: "packet-cursor-rt",
+      sourceAgent: "cursor",
+      targetAgent: "claude-code",
+      createdAt: "2026-03-04T23:10:00.000Z",
+      native,
+    });
+
+    const restored = deserializeCursorContext(packet);
+
+    expect(restored.native).toEqual(native);
+    expect(restored.actions).toEqual({
+      createNotepads: native.notepads,
+      openFiles: native.editor.openFiles,
+      activeFile: native.editor.activeFile,
+    });
   });
 });

--- a/packages/core/src/context-packet-serializers.ts
+++ b/packages/core/src/context-packet-serializers.ts
@@ -61,6 +61,24 @@ export interface CursorSerializerInput extends BaseSerializerInput {
   };
 }
 
+export interface ClaudeCodeDeserializerOutput {
+  native: ClaudeCodeSerializerInput["native"];
+  memoryWrite: {
+    filePath: "MEMORY.md";
+    mode: "prepend";
+    content: string;
+  };
+}
+
+export interface CursorDeserializerOutput {
+  native: CursorSerializerInput["native"];
+  actions: {
+    createNotepads: CursorNotepad[];
+    openFiles: string[];
+    activeFile?: string;
+  };
+}
+
 function buildBasePacket(input: BaseSerializerInput): ContextPacket {
   return {
     packetId: input.id,
@@ -115,4 +133,50 @@ export function serializeCursorContext(input: CursorSerializerInput): ContextPac
   };
 
   return ContextPacketSchema.parse(packet);
+}
+
+function prependSummaryToMemory(summary: string, memoryMd: string): string {
+  if (!summary.trim()) {
+    return memoryMd;
+  }
+
+  return `## Handoff Summary\n${summary}\n\n${memoryMd}`;
+}
+
+export function deserializeClaudeCodeContext(packet: ContextPacket): ClaudeCodeDeserializerOutput {
+  const parsed = ContextPacketSchema.parse(packet);
+  const claudeCode = parsed.workingContext["claudeCode"] as
+    | ClaudeCodeSerializerInput["native"]
+    | undefined;
+
+  if (!claudeCode) {
+    throw new Error("Context packet is missing workingContext.claudeCode payload");
+  }
+
+  return {
+    native: claudeCode,
+    memoryWrite: {
+      filePath: "MEMORY.md",
+      mode: "prepend",
+      content: prependSummaryToMemory(parsed.conversationSummary, claudeCode.memoryMd),
+    },
+  };
+}
+
+export function deserializeCursorContext(packet: ContextPacket): CursorDeserializerOutput {
+  const parsed = ContextPacketSchema.parse(packet);
+  const cursor = parsed.workingContext["cursor"] as CursorSerializerInput["native"] | undefined;
+
+  if (!cursor) {
+    throw new Error("Context packet is missing workingContext.cursor payload");
+  }
+
+  return {
+    native: cursor,
+    actions: {
+      createNotepads: cursor.notepads,
+      openFiles: cursor.editor.openFiles,
+      ...(cursor.editor.activeFile ? { activeFile: cursor.editor.activeFile } : {}),
+    },
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,13 +54,17 @@ export {
   TieredCache,
 } from "./cache.js";
 export type {
+  ClaudeCodeDeserializerOutput,
   ClaudeCodeSerializerInput,
   ClaudeCodeTaskContext,
+  CursorDeserializerOutput,
   CursorEditorSelection,
   CursorNotepad,
   CursorSerializerInput,
 } from "./context-packet-serializers.js";
 export {
+  deserializeClaudeCodeContext,
+  deserializeCursorContext,
   serializeClaudeCodeContext,
   serializeCursorContext,
 } from "./context-packet-serializers.js";


### PR DESCRIPTION
## Summary
- add Claude Code and Cursor context packet deserializers for HAND-003
- Claude deserializer returns a prepend write payload for `MEMORY.md` including conversation summary
- Cursor deserializer returns native restoration plus actions to create notepads and reopen files
- add round-trip tests validating deserialize(serialize(input)) equivalence and native action payloads
- export new deserializer types/functions from `@laup/core`

## Validation
- `pnpm exec vitest run packages/core/src/__tests__/context-packet-serializers.test.ts`
- `pnpm --filter @laup/core typecheck`
- `pnpm exec biome check packages/core/src/context-packet-serializers.ts packages/core/src/__tests__/context-packet-serializers.test.ts packages/core/src/index.ts`

Closes #76
