### PR TITLE
feat(core): support synchronous handoff mode (HAND-004)

### DIFF
--- a/packages/core/src/__tests__/handoff-manager.test.ts
+++ b/packages/core/src/__tests__/handoff-manager.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HandoffManager, HandoffTimeoutError } from "../handoff-manager.js";
+import type { ContextPacket } from "../handoff-schema.js";
+
+describe("handoff-manager (HAND-004)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const packet: ContextPacket = {
+    packetId: "packet-77",
+    schemaVersion: "1.0.0",
+    sendingTool: "codex",
+    receivingTool: "claude",
+    task: { type: "implement" },
+    workingContext: { mode: "sync", timeoutSeconds: 60 },
+    memoryRefs: [],
+    conversationSummary: "sync handoff",
+    constraints: [],
+    permissionPolicy: {},
+    timestamp: "2026-03-05T07:00:00Z",
+    compressed: false,
+  };
+
+  it("blocks in sync mode until the receiving agent acknowledges", async () => {
+    let resolveAck:
+      | ((value: {
+          packetId: string;
+          agentId: string;
+          status: "accepted";
+          timestamp: string;
+        }) => void)
+      | undefined;
+    const manager = new HandoffManager();
+
+    const sendPromise = manager.send(packet, {
+      sourceAgent: "sender-1",
+      targetAgent: "receiver-1",
+      mode: "sync",
+      waitForAck: () =>
+        new Promise((resolve) => {
+          resolveAck = resolve;
+        }),
+    });
+
+    let settled = false;
+    void sendPromise.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveAck?.({
+      packetId: packet.packetId,
+      agentId: "receiver-1",
+      status: "accepted",
+      timestamp: "2026-03-05T07:00:05Z",
+    });
+
+    const result = await sendPromise;
+    expect(result.status).toBe("acknowledged");
+    expect(result.history.status).toBe("acknowledged");
+    expect(result.history.timestamps.acknowledged).toBe("2026-03-05T07:00:05Z");
+  });
+
+  it("uses a default timeout of 60 seconds", async () => {
+    vi.useFakeTimers();
+    const manager = new HandoffManager();
+
+    const sendPromise = manager.send(packet, {
+      sourceAgent: "sender-1",
+      targetAgent: "receiver-1",
+      mode: "sync",
+      waitForAck: () => new Promise(() => {}),
+    });
+
+    await vi.advanceTimersByTimeAsync(59_999);
+    await Promise.resolve();
+
+    let rejected = false;
+    void sendPromise.catch(() => {
+      rejected = true;
+    });
+    expect(rejected).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(sendPromise).rejects.toBeInstanceOf(HandoffTimeoutError);
+    expect(manager.getHistory()).toHaveLength(1);
+    expect(manager.getHistory()[0]?.status).toBe("timeout");
+  });
+
+  it("records acknowledgment details in handoff history", async () => {
+    const manager = new HandoffManager();
+
+    const result = await manager.send(packet, {
+      sourceAgent: "sender-1",
+      targetAgent: "receiver-1",
+      mode: "sync",
+      waitForAck: async () => ({
+        packetId: packet.packetId,
+        agentId: "receiver-1",
+        status: "accepted",
+        timestamp: "2026-03-05T07:00:10Z",
+      }),
+    });
+
+    expect(result.history.mode).toBe("sync");
+    expect(result.history.status).toBe("acknowledged");
+    expect(result.history.timestamps.sent).toBeDefined();
+    expect(result.history.timestamps.acknowledged).toBe("2026-03-05T07:00:10Z");
+    expect(result.history.timestamps.completed).toBeDefined();
+  });
+});

--- a/packages/core/src/handoff-manager.ts
+++ b/packages/core/src/handoff-manager.ts
@@ -1,0 +1,145 @@
+import type {
+  ContextPacket,
+  HandoffAck,
+  HandoffHistoryEntry,
+  HandoffMode,
+} from "./handoff-schema.js";
+
+export class HandoffTimeoutError extends Error {
+  readonly packetId: string;
+  readonly timeoutSeconds: number;
+
+  constructor(packetId: string, timeoutSeconds: number) {
+    super(
+      `Timed out waiting for handoff acknowledgment for packet "${packetId}" after ${timeoutSeconds} seconds`,
+    );
+    this.name = "HandoffTimeoutError";
+    this.packetId = packetId;
+    this.timeoutSeconds = timeoutSeconds;
+  }
+}
+
+export interface SendHandoffOptions {
+  mode?: HandoffMode;
+  timeoutSeconds?: number;
+  sourceAgent: string;
+  targetAgent: string;
+  waitForAck?: () => Promise<HandoffAck>;
+}
+
+export interface SendHandoffResult {
+  status: "sent" | "acknowledged" | "rejected";
+  ack?: HandoffAck;
+  history: HandoffHistoryEntry;
+}
+
+export class HandoffManager {
+  private readonly history: HandoffHistoryEntry[] = [];
+  private readonly now: () => Date;
+
+  constructor(options?: { now?: () => Date }) {
+    this.now = options?.now ?? (() => new Date());
+  }
+
+  getHistory(): HandoffHistoryEntry[] {
+    return [...this.history];
+  }
+
+  async send(packet: ContextPacket, options: SendHandoffOptions): Promise<SendHandoffResult> {
+    const mode = options.mode ?? "sync";
+    const timeoutSeconds = options.timeoutSeconds ?? 60;
+    const createdAt = this.now().toISOString();
+
+    const historyEntry: HandoffHistoryEntry = {
+      id: `${packet.packetId}:${createdAt}`,
+      packetId: packet.packetId,
+      sourceAgent: options.sourceAgent,
+      targetAgent: options.targetAgent,
+      mode,
+      status: "pending",
+      timestamps: {
+        created: createdAt,
+      },
+      packetSizeBytes: JSON.stringify(packet).length,
+    };
+
+    historyEntry.status = "sent";
+    historyEntry.timestamps.sent = this.now().toISOString();
+
+    if (mode === "async") {
+      historyEntry.timestamps.completed = this.now().toISOString();
+      historyEntry.durationMs = this.toDurationMs(
+        historyEntry.timestamps.created,
+        historyEntry.timestamps.completed,
+      );
+      this.history.push(historyEntry);
+      return { status: "sent", history: historyEntry };
+    }
+
+    if (!options.waitForAck) {
+      throw new Error("waitForAck is required for sync handoff mode");
+    }
+
+    try {
+      const ack = await waitForAckWithTimeout(options.waitForAck, packet.packetId, timeoutSeconds);
+      historyEntry.timestamps.acknowledged = ack.timestamp;
+      historyEntry.timestamps.completed = this.now().toISOString();
+      historyEntry.status = ack.status === "accepted" ? "acknowledged" : "rejected";
+      historyEntry.durationMs = this.toDurationMs(
+        historyEntry.timestamps.created,
+        historyEntry.timestamps.completed,
+      );
+      if (ack.status === "rejected" && ack.reason) {
+        historyEntry.error = ack.reason;
+      }
+      this.history.push(historyEntry);
+      return {
+        status: historyEntry.status,
+        ack,
+        history: historyEntry,
+      };
+    } catch (error) {
+      if (error instanceof HandoffTimeoutError) {
+        historyEntry.status = "timeout";
+        historyEntry.error = error.message;
+        historyEntry.timestamps.completed = this.now().toISOString();
+        historyEntry.durationMs = this.toDurationMs(
+          historyEntry.timestamps.created,
+          historyEntry.timestamps.completed,
+        );
+        this.history.push(historyEntry);
+      }
+      throw error;
+    }
+  }
+
+  private toDurationMs(startIso: string, endIso?: string): number | undefined {
+    if (!endIso) return undefined;
+    const start = Date.parse(startIso);
+    const end = Date.parse(endIso);
+    if (Number.isNaN(start) || Number.isNaN(end)) return undefined;
+    return Math.max(0, end - start);
+  }
+}
+
+export async function waitForAckWithTimeout(
+  waitForAck: () => Promise<HandoffAck>,
+  packetId: string,
+  timeoutSeconds = 60,
+): Promise<HandoffAck> {
+  return new Promise<HandoffAck>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new HandoffTimeoutError(packetId, timeoutSeconds));
+    }, timeoutSeconds * 1000);
+
+    void waitForAck()
+      .then((ack) => {
+        clearTimeout(timer);
+        resolve(ack);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -176,6 +176,12 @@ export {
   createMigrator,
   Migrator,
 } from "./db-migrations.js";
+export type { SendHandoffOptions, SendHandoffResult } from "./handoff-manager.js";
+export {
+  HandoffManager,
+  HandoffTimeoutError,
+  waitForAckWithTimeout,
+} from "./handoff-manager.js";
 export type {
   HandoffRoutingCandidate,
   HandoffRoutingDecision as ResolvedHandoffRoutingDecision,


### PR DESCRIPTION
## Summary
- add a `HandoffManager` that supports synchronous handoff delivery, waiting for receiver acknowledgment before completion
- add configurable timeout handling (default 60s) with `HandoffTimeoutError` so timeouts surface as sender errors
- record sent/ack/completed timestamps and final status in `HandoffHistoryEntry` for sync/async handoffs
- export new handoff manager APIs from `@laup/core` and add HAND-004 focused tests

## Validation
- `pnpm test:run -- packages/core/src/__tests__/handoff-manager.test.ts packages/core/src/__tests__/handoff-schema.test.ts`
- `pnpm --filter @laup/core typecheck`

Closes #77
