### PR TITLE
feat(core): support async handoff queue delivery (HAND-005)

### DIFF
--- a/packages/core/src/__tests__/handoff-queue.test.ts
+++ b/packages/core/src/__tests__/handoff-queue.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { createHandoffQueue, MIN_HANDOFF_RETENTION_MS } from "../handoff-queue.js";
+import type { ContextPacket } from "../handoff-schema.js";
+
+describe("handoff-queue (HAND-005)", () => {
+  const packet = (id: string, receivingTool = "claude-code"): ContextPacket => ({
+    packetId: id,
+    schemaVersion: "1.0.0",
+    sendingTool: "codex",
+    receivingTool,
+    task: { title: "ship async handoff" },
+    workingContext: {},
+    memoryRefs: [],
+    conversationSummary: "handoff",
+    constraints: [],
+    permissionPolicy: {},
+    timestamp: "2026-03-01T00:00:00.000Z",
+    compressed: false,
+  });
+
+  it("enqueues async packet and returns immediately with queued status", async () => {
+    const queue = createHandoffQueue();
+    const record = await queue.enqueue(packet("pkt-1"));
+
+    expect(record.packetId).toBe("pkt-1");
+    expect(record.status).toBe("queued");
+
+    const status = await queue.getStatus("pkt-1");
+    expect(status?.status).toBe("queued");
+  });
+
+  it("enforces minimum retention of 7 days with configurable value", () => {
+    expect(() => createHandoffQueue({ retentionMs: MIN_HANDOFF_RETENTION_MS - 1 })).toThrow(
+      /at least 7 days/i,
+    );
+
+    expect(() => createHandoffQueue({ retentionMs: MIN_HANDOFF_RETENTION_MS + 1 })).not.toThrow();
+  });
+
+  it("lets receiving agent poll for new packets and tracks delivered status", async () => {
+    const queue = createHandoffQueue();
+    await queue.enqueue(packet("pkt-2", "claude-code"));
+    await queue.enqueue(packet("pkt-3", "copilot"));
+
+    const pulled = await queue.poll("claude-code");
+    expect(pulled).toHaveLength(1);
+    expect(pulled[0]?.packetId).toBe("pkt-2");
+
+    const deliveredStatus = await queue.getStatus("pkt-2");
+    expect(deliveredStatus?.status).toBe("delivered");
+    expect(deliveredStatus?.deliveredAt).toBeTruthy();
+
+    const secondPoll = await queue.poll("claude-code");
+    expect(secondPoll).toHaveLength(0);
+  });
+
+  it("supports subscribe mode for new packets", async () => {
+    const queue = createHandoffQueue();
+
+    const seen: string[] = [];
+    const unsubscribe = queue.subscribe("claude-code", async (queuedPacket) => {
+      seen.push(queuedPacket.packetId);
+    });
+
+    await queue.enqueue(packet("pkt-4", "claude-code"));
+    await Promise.resolve();
+
+    expect(seen).toEqual(["pkt-4"]);
+
+    unsubscribe();
+    await queue.enqueue(packet("pkt-5", "claude-code"));
+    await Promise.resolve();
+
+    expect(seen).toEqual(["pkt-4"]);
+  });
+});

--- a/packages/core/src/handoff-queue.ts
+++ b/packages/core/src/handoff-queue.ts
@@ -1,0 +1,140 @@
+import type { ContextPacket } from "./handoff-schema.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const MIN_HANDOFF_RETENTION_MS = 7 * DAY_MS;
+
+export type HandoffQueuePacketStatus = "queued" | "delivered" | "expired";
+
+export interface HandoffQueueRecord {
+  packetId: string;
+  status: HandoffQueuePacketStatus;
+  queuedAt: string;
+  expiresAt: string;
+  deliveredAt?: string;
+}
+
+export interface HandoffQueueOptions {
+  /** Retention window for queued/delivered packet records. Must be >= 7 days. */
+  retentionMs?: number;
+  /** Clock source override for deterministic tests. */
+  now?: () => Date;
+}
+
+export type HandoffSubscriber = (
+  packet: ContextPacket,
+  record: HandoffQueueRecord,
+) => void | Promise<void>;
+
+export interface HandoffQueue {
+  enqueue(packet: ContextPacket): Promise<HandoffQueueRecord>;
+  getStatus(packetId: string): Promise<HandoffQueueRecord | null>;
+  poll(receivingTool: string, options?: { limit?: number }): Promise<ContextPacket[]>;
+  subscribe(receivingTool: string, handler: HandoffSubscriber): () => void;
+  pruneExpired(now?: Date): Promise<number>;
+}
+
+interface QueueEntry {
+  packet: ContextPacket;
+  record: HandoffQueueRecord;
+}
+
+export class InMemoryHandoffQueue implements HandoffQueue {
+  private readonly entries = new Map<string, QueueEntry>();
+  private readonly subscribers = new Map<string, Set<HandoffSubscriber>>();
+  private readonly retentionMs: number;
+  private readonly now: () => Date;
+
+  constructor(options: HandoffQueueOptions = {}) {
+    const retentionMs = options.retentionMs ?? MIN_HANDOFF_RETENTION_MS;
+    if (retentionMs < MIN_HANDOFF_RETENTION_MS) {
+      throw new Error("Handoff queue retention must be at least 7 days");
+    }
+
+    this.retentionMs = retentionMs;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async enqueue(packet: ContextPacket): Promise<HandoffQueueRecord> {
+    const now = this.now();
+
+    const record: HandoffQueueRecord = {
+      packetId: packet.packetId,
+      status: "queued",
+      queuedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + this.retentionMs).toISOString(),
+    };
+
+    this.entries.set(packet.packetId, { packet, record });
+
+    const handlers = this.subscribers.get(packet.receivingTool);
+    if (handlers && handlers.size > 0) {
+      for (const handler of handlers) {
+        queueMicrotask(() => {
+          Promise.resolve(handler(packet, { ...record })).catch(() => {});
+        });
+      }
+    }
+
+    return { ...record };
+  }
+
+  async getStatus(packetId: string): Promise<HandoffQueueRecord | null> {
+    const entry = this.entries.get(packetId);
+    if (!entry) return null;
+    return { ...entry.record };
+  }
+
+  async poll(receivingTool: string, options?: { limit?: number }): Promise<ContextPacket[]> {
+    const now = this.now();
+    const limit = options?.limit ?? Number.POSITIVE_INFINITY;
+
+    const queued = Array.from(this.entries.values())
+      .filter((entry) => {
+        if (entry.packet.receivingTool !== receivingTool) return false;
+        if (entry.record.status !== "queued") return false;
+        return new Date(entry.record.expiresAt).getTime() > now.getTime();
+      })
+      .sort((a, b) => a.record.queuedAt.localeCompare(b.record.queuedAt))
+      .slice(0, limit);
+
+    for (const entry of queued) {
+      entry.record.status = "delivered";
+      entry.record.deliveredAt = now.toISOString();
+    }
+
+    return queued.map((entry) => entry.packet);
+  }
+
+  subscribe(receivingTool: string, handler: HandoffSubscriber): () => void {
+    const handlers = this.subscribers.get(receivingTool) ?? new Set<HandoffSubscriber>();
+    handlers.add(handler);
+    this.subscribers.set(receivingTool, handlers);
+
+    return () => {
+      const current = this.subscribers.get(receivingTool);
+      if (!current) return;
+      current.delete(handler);
+      if (current.size === 0) {
+        this.subscribers.delete(receivingTool);
+      }
+    };
+  }
+
+  async pruneExpired(now = this.now()): Promise<number> {
+    let pruned = 0;
+
+    for (const [packetId, entry] of this.entries) {
+      if (new Date(entry.record.expiresAt).getTime() <= now.getTime()) {
+        entry.record.status = "expired";
+        this.entries.delete(packetId);
+        pruned++;
+      }
+    }
+
+    return pruned;
+  }
+}
+
+export function createHandoffQueue(options?: HandoffQueueOptions): HandoffQueue {
+  return new InMemoryHandoffQueue(options);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,6 +181,18 @@ export {
   Migrator,
 } from "./db-migrations.js";
 export type {
+  HandoffQueue,
+  HandoffQueueOptions,
+  HandoffQueuePacketStatus,
+  HandoffQueueRecord,
+  HandoffSubscriber,
+} from "./handoff-queue.js";
+export {
+  createHandoffQueue,
+  InMemoryHandoffQueue,
+  MIN_HANDOFF_RETENTION_MS,
+} from "./handoff-queue.js";
+export type {
   HandoffRoutingCandidate,
   HandoffRoutingDecision as ResolvedHandoffRoutingDecision,
   HandoffRoutingPolicyConfig,


### PR DESCRIPTION
## Summary\n- add a dedicated in-memory handoff queue for async mode delivery\n- support packet enqueue, packetId status tracking, polling, and subscription for new packets\n- enforce configurable retention with a minimum of 7 days\n- export queue types/factory from core index\n- add HAND-005 test coverage for enqueue, retention, status, poll, and subscribe flows\n\n## Validation\n- pnpm exec vitest run packages/core/src/__tests__/handoff-queue.test.ts packages/core/src/__tests__/handoff-schema.test.ts\n- pnpm --filter @laup/core typecheck\n\nCloses #78