### PR TITLE
feat(core): implement HAND-008 handoff history + audit trail

### DIFF
--- a/packages/core/src/__tests__/handoff-history.test.ts
+++ b/packages/core/src/__tests__/handoff-history.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryAuditStorage } from "../audit-storage.js";
+import { InMemoryDbAdapter } from "../db-adapter.js";
+import {
+  type HandoffHistoryStorage,
+  InMemoryHandoffHistoryStorage,
+  MIN_HANDOFF_HISTORY_RETENTION_MONTHS,
+  SqlHandoffHistoryStorage,
+} from "../handoff-history.js";
+
+describe("handoff-history (HAND-008)", () => {
+  let storage: HandoffHistoryStorage;
+
+  beforeEach(async () => {
+    storage = new InMemoryHandoffHistoryStorage(() => new Date("2026-03-05T08:00:00.000Z"));
+    await storage.init();
+  });
+
+  it("records sent/received/acknowledged lifecycle events with required metadata", async () => {
+    await storage.recordSent({
+      packetId: "packet-1",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Implement HAND-008",
+      sentAt: "2026-03-05T07:00:00.000Z",
+    });
+    await storage.recordReceived({
+      packetId: "packet-1",
+      eventAt: "2026-03-05T07:00:02.000Z",
+    });
+    await storage.recordAcknowledged({
+      packetId: "packet-1",
+      eventAt: "2026-03-05T07:00:05.000Z",
+    });
+
+    const events = await storage.query({ packetId: "packet-1" });
+    expect(events.map((event) => event.status)).toEqual(["sent", "received", "acknowledged"]);
+    expect(events[2]).toMatchObject({
+      packetId: "packet-1",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Implement HAND-008",
+      sentAt: "2026-03-05T07:00:00.000Z",
+      eventAt: "2026-03-05T07:00:05.000Z",
+      status: "acknowledged",
+    });
+  });
+
+  it("records rejected and expired events", async () => {
+    await storage.recordSent({
+      packetId: "packet-2",
+      sendingTool: "cursor",
+      receivingTool: "codex",
+      taskSummary: "Analyze traces",
+      sentAt: "2026-03-05T07:10:00.000Z",
+    });
+    await storage.recordRejected({ packetId: "packet-2", eventAt: "2026-03-05T07:11:00.000Z" });
+
+    await storage.recordSent({
+      packetId: "packet-3",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Run tests",
+      sentAt: "2026-03-05T07:20:00.000Z",
+    });
+    await storage.recordExpired({ packetId: "packet-3", eventAt: "2026-03-05T07:30:00.000Z" });
+
+    const rejected = await storage.query({ status: "rejected" });
+    const expired = await storage.query({ status: "expired" });
+
+    expect(rejected).toHaveLength(1);
+    expect(expired).toHaveLength(1);
+    expect(rejected[0]?.packetId).toBe("packet-2");
+    expect(expired[0]?.packetId).toBe("packet-3");
+  });
+
+  it("supports querying by packetId, tool, date range, and status", async () => {
+    await storage.recordSent({
+      packetId: "packet-a",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Task A",
+      sentAt: "2026-03-04T23:59:59.000Z",
+    });
+    await storage.recordSent({
+      packetId: "packet-b",
+      sendingTool: "codex",
+      receivingTool: "cursor",
+      taskSummary: "Task B",
+      sentAt: "2026-03-05T07:00:00.000Z",
+    });
+    await storage.recordReceived({ packetId: "packet-b", eventAt: "2026-03-05T07:00:03.000Z" });
+
+    const byPacket = await storage.query({ packetId: "packet-b" });
+    expect(byPacket).toHaveLength(2);
+
+    const byTool = await storage.query({ tool: "cursor" });
+    expect(byTool.map((event) => event.packetId)).toEqual(["packet-b", "packet-b"]);
+
+    const byDate = await storage.query({
+      startTime: new Date("2026-03-05T00:00:00.000Z"),
+      endTime: new Date("2026-03-06T00:00:00.000Z"),
+    });
+    expect(byDate.every((event) => event.packetId === "packet-b")).toBe(true);
+
+    const byStatus = await storage.query({ status: "received" });
+    expect(byStatus).toHaveLength(1);
+    expect(byStatus[0]?.packetId).toBe("packet-b");
+  });
+
+  it("retains at least 24 months when pruning", async () => {
+    await storage.recordSent({
+      packetId: "packet-keep",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Keep me",
+      sentAt: "2024-03-10T00:00:00.000Z",
+    });
+    await storage.recordSent({
+      packetId: "packet-drop",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Drop me",
+      sentAt: "2024-03-01T23:59:59.000Z",
+    });
+
+    const pruned = await storage.prune(new Date("2026-03-01T00:00:00.000Z"));
+    expect(pruned).toBe(1);
+
+    const remaining = await storage.query({});
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.packetId).toBe("packet-keep");
+    expect(MIN_HANDOFF_HISTORY_RETENTION_MONTHS).toBe(24);
+  });
+
+  it("writes handoff lifecycle entries into audit trail integration", async () => {
+    const auditStorage = new InMemoryAuditStorage();
+    await auditStorage.init();
+    const auditedStorage = new InMemoryHandoffHistoryStorage(
+      () => new Date("2026-03-05T08:00:00.000Z"),
+      auditStorage,
+    );
+    await auditedStorage.init();
+
+    await auditedStorage.recordSent({
+      packetId: "packet-audit",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Audit me",
+      sentAt: "2026-03-05T07:00:00.000Z",
+    });
+
+    const auditPage = await auditStorage.query({ category: "handoff" });
+    expect(auditPage.total).toBe(1);
+    expect(auditPage.entries[0]).toMatchObject({
+      category: "handoff",
+      action: "handoff.sent",
+      targetId: "packet-audit",
+      metadata: expect.objectContaining({ status: "sent" }),
+    });
+  });
+
+  it("persists sql history records", async () => {
+    const db = new InMemoryDbAdapter();
+    await db.connect();
+
+    const sqlStorage = new SqlHandoffHistoryStorage(db, () => new Date("2026-03-05T08:00:00.000Z"));
+    await sqlStorage.init();
+
+    await sqlStorage.recordSent({
+      packetId: "packet-sql",
+      sendingTool: "codex",
+      receivingTool: "claude-code",
+      taskSummary: "Persist in SQL",
+      sentAt: "2026-03-05T07:00:00.000Z",
+    });
+
+    const rows = await db.query<{ packet_id: string; status: string }>(
+      "SELECT packet_id, status FROM handoff_history_events",
+    );
+    expect(rows.rowCount).toBe(1);
+    expect(rows.rows[0]).toMatchObject({
+      packet_id: "packet-sql",
+      status: "sent",
+    });
+
+    await db.disconnect();
+  });
+});

--- a/packages/core/src/__tests__/handoff-manager.test.ts
+++ b/packages/core/src/__tests__/handoff-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { InMemoryHandoffHistoryStorage } from "../handoff-history.js";
 import { HandoffManager, HandoffTimeoutError } from "../handoff-manager.js";
 import type { ContextPacket } from "../handoff-schema.js";
 
@@ -111,5 +112,36 @@ describe("handoff-manager (HAND-004)", () => {
     expect(result.history.timestamps.sent).toBeDefined();
     expect(result.history.timestamps.acknowledged).toBe("2026-03-05T07:00:10Z");
     expect(result.history.timestamps.completed).toBeDefined();
+  });
+
+  it("writes handoff lifecycle events into HAND-008 storage", async () => {
+    const historyStorage = new InMemoryHandoffHistoryStorage();
+    await historyStorage.init();
+
+    const manager = new HandoffManager({ historyStorage });
+    await manager.send(packet, {
+      sourceAgent: "sender-1",
+      targetAgent: "receiver-1",
+      mode: "sync",
+      waitForAck: async () => ({
+        packetId: packet.packetId,
+        agentId: "receiver-1",
+        status: "accepted",
+        timestamp: "2026-03-05T07:00:10Z",
+      }),
+    });
+
+    const events = await historyStorage.query({ packetId: packet.packetId });
+    expect(events).toHaveLength(3);
+    expect(events.map((event) => event.status).sort()).toEqual([
+      "acknowledged",
+      "received",
+      "sent",
+    ]);
+    expect(events[0]).toMatchObject({
+      packetId: packet.packetId,
+      sendingTool: packet.sendingTool,
+      receivingTool: packet.receivingTool,
+    });
   });
 });

--- a/packages/core/src/audit-storage.ts
+++ b/packages/core/src/audit-storage.ts
@@ -19,6 +19,7 @@ export const AuditCategorySchema = z.enum([
   "mcp", // MCP server operations
   "skill", // Skill operations
   "memory", // Memory read/write/search operations
+  "handoff", // Handoff history and lifecycle events
 ]);
 
 export type AuditCategory = z.infer<typeof AuditCategorySchema>;

--- a/packages/core/src/handoff-history.ts
+++ b/packages/core/src/handoff-history.ts
@@ -1,0 +1,394 @@
+import type { AuditStorage } from "./audit-storage.js";
+import type { DbAdapter } from "./db-adapter.js";
+
+export const MIN_HANDOFF_HISTORY_RETENTION_MONTHS = 24;
+
+export type HandoffHistoryStatus = "sent" | "received" | "acknowledged" | "expired" | "rejected";
+
+export interface HandoffHistoryRecord {
+  id: string;
+  packetId: string;
+  sendingTool: string;
+  receivingTool: string;
+  taskSummary: string;
+  sentAt: string;
+  eventAt: string;
+  status: HandoffHistoryStatus;
+}
+
+export interface HandoffHistoryQuery {
+  packetId?: string;
+  tool?: string;
+  startTime?: Date;
+  endTime?: Date;
+  status?: HandoffHistoryStatus;
+}
+
+export interface HandoffRecordSentInput {
+  packetId: string;
+  sendingTool: string;
+  receivingTool: string;
+  taskSummary: string;
+  sentAt?: string;
+}
+
+export interface HandoffRecordStatusInput {
+  packetId: string;
+  status: Exclude<HandoffHistoryStatus, "sent">;
+  eventAt?: string;
+  sendingTool?: string;
+  receivingTool?: string;
+  taskSummary?: string;
+  sentAt?: string;
+}
+
+export interface HandoffHistoryStorage {
+  init(): Promise<void>;
+  recordSent(input: HandoffRecordSentInput): Promise<string>;
+  recordReceived(input: Omit<HandoffRecordStatusInput, "status">): Promise<string>;
+  recordAcknowledged(input: Omit<HandoffRecordStatusInput, "status">): Promise<string>;
+  recordExpired(input: Omit<HandoffRecordStatusInput, "status">): Promise<string>;
+  recordRejected(input: Omit<HandoffRecordStatusInput, "status">): Promise<string>;
+  query(filter: HandoffHistoryQuery): Promise<HandoffHistoryRecord[]>;
+  prune(before?: Date): Promise<number>;
+}
+
+function retentionCutoffFrom(now: Date): Date {
+  return new Date(
+    Date.UTC(
+      now.getUTCFullYear(),
+      now.getUTCMonth() - MIN_HANDOFF_HISTORY_RETENTION_MONTHS,
+      now.getUTCDate(),
+      now.getUTCHours(),
+      now.getUTCMinutes(),
+      now.getUTCSeconds(),
+      now.getUTCMilliseconds(),
+    ),
+  );
+}
+
+function effectivePruneBefore(now: Date, before?: Date): Date {
+  const retentionCutoff = retentionCutoffFrom(now);
+  if (!before) return retentionCutoff;
+  return before.getTime() < retentionCutoff.getTime() ? before : retentionCutoff;
+}
+
+function matchesFilter(record: HandoffHistoryRecord, filter: HandoffHistoryQuery): boolean {
+  if (filter.packetId && record.packetId !== filter.packetId) return false;
+  if (filter.status && record.status !== filter.status) return false;
+  if (filter.tool && record.sendingTool !== filter.tool && record.receivingTool !== filter.tool) {
+    return false;
+  }
+
+  const time = new Date(record.eventAt).getTime();
+  if (filter.startTime && time < filter.startTime.getTime()) return false;
+  if (filter.endTime && time >= filter.endTime.getTime()) return false;
+
+  return true;
+}
+
+async function appendHandoffAudit(
+  auditStorage: AuditStorage | undefined,
+  record: HandoffHistoryRecord,
+): Promise<void> {
+  if (!auditStorage) return;
+
+  await auditStorage.append({
+    category: "handoff",
+    action: `handoff.${record.status}`,
+    actor: record.sendingTool,
+    targetId: record.packetId,
+    targetType: "context-packet",
+    severity: "info",
+    metadata: {
+      packetId: record.packetId,
+      sendingTool: record.sendingTool,
+      receivingTool: record.receivingTool,
+      taskSummary: record.taskSummary,
+      sentAt: record.sentAt,
+      eventAt: record.eventAt,
+      status: record.status,
+    },
+  });
+}
+
+export class InMemoryHandoffHistoryStorage implements HandoffHistoryStorage {
+  private records: HandoffHistoryRecord[] = [];
+  private nextId = 1;
+
+  constructor(
+    private now: () => Date = () => new Date(),
+    private auditStorage?: AuditStorage,
+  ) {}
+
+  async init(): Promise<void> {}
+
+  async recordSent(input: HandoffRecordSentInput): Promise<string> {
+    const sentAt = input.sentAt ?? this.now().toISOString();
+    return this.appendRecord({
+      packetId: input.packetId,
+      sendingTool: input.sendingTool,
+      receivingTool: input.receivingTool,
+      taskSummary: input.taskSummary,
+      sentAt,
+      status: "sent",
+      eventAt: sentAt,
+    });
+  }
+
+  async recordReceived(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "received" });
+  }
+
+  async recordAcknowledged(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "acknowledged" });
+  }
+
+  async recordExpired(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "expired" });
+  }
+
+  async recordRejected(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "rejected" });
+  }
+
+  async query(filter: HandoffHistoryQuery): Promise<HandoffHistoryRecord[]> {
+    return this.records
+      .filter((record) => matchesFilter(record, filter))
+      .sort((a, b) => a.eventAt.localeCompare(b.eventAt));
+  }
+
+  async prune(before?: Date): Promise<number> {
+    const pruneBefore = effectivePruneBefore(this.now(), before);
+    const pruneBeforeMs = pruneBefore.getTime();
+
+    const keep: HandoffHistoryRecord[] = [];
+    let pruned = 0;
+    for (const record of this.records) {
+      if (new Date(record.eventAt).getTime() < pruneBeforeMs) {
+        pruned += 1;
+        continue;
+      }
+      keep.push(record);
+    }
+
+    this.records = keep;
+    return pruned;
+  }
+
+  private async recordStatus(input: HandoffRecordStatusInput): Promise<string> {
+    const baseline = this.getBaseline(input.packetId);
+    if (
+      !baseline &&
+      (!input.sendingTool || !input.receivingTool || !input.taskSummary || !input.sentAt)
+    ) {
+      throw new Error(
+        `Missing packet context for ${input.packetId}. Provide sendingTool, receivingTool, taskSummary, and sentAt when no sent record exists.`,
+      );
+    }
+
+    const eventAt = input.eventAt ?? this.now().toISOString();
+    return this.appendRecord({
+      packetId: input.packetId,
+      sendingTool: input.sendingTool ?? baseline!.sendingTool,
+      receivingTool: input.receivingTool ?? baseline!.receivingTool,
+      taskSummary: input.taskSummary ?? baseline!.taskSummary,
+      sentAt: input.sentAt ?? baseline!.sentAt,
+      eventAt,
+      status: input.status,
+    });
+  }
+
+  private getBaseline(packetId: string): HandoffHistoryRecord | undefined {
+    const matches = this.records.filter((record) => record.packetId === packetId);
+    if (matches.length === 0) return undefined;
+    return matches.reduce((latest, current) =>
+      current.eventAt.localeCompare(latest.eventAt) > 0 ? current : latest,
+    );
+  }
+
+  private async appendRecord(record: Omit<HandoffHistoryRecord, "id">): Promise<string> {
+    const id = `handoff_hist_${this.nextId++}`;
+    const fullRecord = { id, ...record };
+    this.records.push(fullRecord);
+    await appendHandoffAudit(this.auditStorage, fullRecord);
+    return id;
+  }
+}
+
+export class SqlHandoffHistoryStorage implements HandoffHistoryStorage {
+  constructor(
+    private db: DbAdapter,
+    private now: () => Date = () => new Date(),
+    private auditStorage?: AuditStorage,
+  ) {}
+
+  async init(): Promise<void> {
+    await this.db.execute(`
+      CREATE TABLE IF NOT EXISTS handoff_history_events (
+        id TEXT PRIMARY KEY,
+        packet_id TEXT NOT NULL,
+        sending_tool TEXT NOT NULL,
+        receiving_tool TEXT NOT NULL,
+        task_summary TEXT NOT NULL,
+        sent_at TEXT NOT NULL,
+        event_at TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_handoff_history_packet_event ON handoff_history_events(packet_id, event_at)`,
+    );
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_handoff_history_status_event ON handoff_history_events(status, event_at)`,
+    );
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_handoff_history_sending_tool_event ON handoff_history_events(sending_tool, event_at)`,
+    );
+    await this.db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_handoff_history_receiving_tool_event ON handoff_history_events(receiving_tool, event_at)`,
+    );
+  }
+
+  async recordSent(input: HandoffRecordSentInput): Promise<string> {
+    const sentAt = input.sentAt ?? this.now().toISOString();
+    return this.appendRecord({
+      packetId: input.packetId,
+      sendingTool: input.sendingTool,
+      receivingTool: input.receivingTool,
+      taskSummary: input.taskSummary,
+      sentAt,
+      status: "sent",
+      eventAt: sentAt,
+    });
+  }
+
+  async recordReceived(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "received" });
+  }
+
+  async recordAcknowledged(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "acknowledged" });
+  }
+
+  async recordExpired(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "expired" });
+  }
+
+  async recordRejected(input: Omit<HandoffRecordStatusInput, "status">): Promise<string> {
+    return this.recordStatus({ ...input, status: "rejected" });
+  }
+
+  async query(filter: HandoffHistoryQuery): Promise<HandoffHistoryRecord[]> {
+    const result = await this.db.query<{
+      id: string;
+      packet_id: string;
+      sending_tool: string;
+      receiving_tool: string;
+      task_summary: string;
+      sent_at: string;
+      event_at: string;
+      status: HandoffHistoryStatus;
+    }>(`SELECT * FROM handoff_history_events ORDER BY event_at ASC`);
+
+    return result.rows
+      .map((row) => ({
+        id: row.id,
+        packetId: row.packet_id,
+        sendingTool: row.sending_tool,
+        receivingTool: row.receiving_tool,
+        taskSummary: row.task_summary,
+        sentAt: row.sent_at,
+        eventAt: row.event_at,
+        status: row.status,
+      }))
+      .filter((record) => matchesFilter(record, filter));
+  }
+
+  async prune(before?: Date): Promise<number> {
+    const pruneBefore = effectivePruneBefore(this.now(), before).toISOString();
+    return this.db.execute(`DELETE FROM handoff_history_events WHERE event_at < ?`, [pruneBefore]);
+  }
+
+  private async recordStatus(input: HandoffRecordStatusInput): Promise<string> {
+    const baseline = await this.getBaseline(input.packetId);
+    if (
+      !baseline &&
+      (!input.sendingTool || !input.receivingTool || !input.taskSummary || !input.sentAt)
+    ) {
+      throw new Error(
+        `Missing packet context for ${input.packetId}. Provide sendingTool, receivingTool, taskSummary, and sentAt when no sent record exists.`,
+      );
+    }
+
+    const eventAt = input.eventAt ?? this.now().toISOString();
+    return this.appendRecord({
+      packetId: input.packetId,
+      sendingTool: input.sendingTool ?? baseline!.sendingTool,
+      receivingTool: input.receivingTool ?? baseline!.receivingTool,
+      taskSummary: input.taskSummary ?? baseline!.taskSummary,
+      sentAt: input.sentAt ?? baseline!.sentAt,
+      eventAt,
+      status: input.status,
+    });
+  }
+
+  private async getBaseline(packetId: string): Promise<HandoffHistoryRecord | undefined> {
+    const row = await this.db.queryOne<{
+      id: string;
+      packet_id: string;
+      sending_tool: string;
+      receiving_tool: string;
+      task_summary: string;
+      sent_at: string;
+      event_at: string;
+      status: HandoffHistoryStatus;
+    }>(`SELECT * FROM handoff_history_events WHERE packet_id = ? ORDER BY event_at DESC LIMIT 1`, [
+      packetId,
+    ]);
+
+    if (!row) return undefined;
+    return {
+      id: row.id,
+      packetId: row.packet_id,
+      sendingTool: row.sending_tool,
+      receivingTool: row.receiving_tool,
+      taskSummary: row.task_summary,
+      sentAt: row.sent_at,
+      eventAt: row.event_at,
+      status: row.status,
+    };
+  }
+
+  private async appendRecord(record: Omit<HandoffHistoryRecord, "id">): Promise<string> {
+    const id = `handoff_hist_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    await this.db.execute(
+      `INSERT INTO handoff_history_events (id, packet_id, sending_tool, receiving_tool, task_summary, sent_at, event_at, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        record.packetId,
+        record.sendingTool,
+        record.receivingTool,
+        record.taskSummary,
+        record.sentAt,
+        record.eventAt,
+        record.status,
+      ],
+    );
+
+    await appendHandoffAudit(this.auditStorage, { id, ...record });
+
+    return id;
+  }
+}
+
+export function createHandoffHistoryStorage(
+  db: DbAdapter,
+  auditStorage?: AuditStorage,
+): HandoffHistoryStorage {
+  return new SqlHandoffHistoryStorage(db, undefined, auditStorage);
+}

--- a/packages/core/src/handoff-manager.ts
+++ b/packages/core/src/handoff-manager.ts
@@ -1,3 +1,4 @@
+import type { HandoffHistoryStorage } from "./handoff-history.js";
 import type {
   ContextPacket,
   HandoffAck,
@@ -36,9 +37,11 @@ export interface SendHandoffResult {
 export class HandoffManager {
   private readonly history: HandoffHistoryEntry[] = [];
   private readonly now: () => Date;
+  private readonly historyStorage: HandoffHistoryStorage | undefined;
 
-  constructor(options?: { now?: () => Date }) {
+  constructor(options?: { now?: () => Date; historyStorage?: HandoffHistoryStorage }) {
     this.now = options?.now ?? (() => new Date());
+    this.historyStorage = options?.historyStorage;
   }
 
   getHistory(): HandoffHistoryEntry[] {
@@ -65,6 +68,13 @@ export class HandoffManager {
 
     historyEntry.status = "sent";
     historyEntry.timestamps.sent = this.now().toISOString();
+    await this.historyStorage?.recordSent({
+      packetId: packet.packetId,
+      sendingTool: packet.sendingTool,
+      receivingTool: packet.receivingTool,
+      taskSummary: summarizeTask(packet.task),
+      sentAt: historyEntry.timestamps.sent,
+    });
 
     if (mode === "async") {
       historyEntry.timestamps.completed = this.now().toISOString();
@@ -83,12 +93,27 @@ export class HandoffManager {
     try {
       const ack = await waitForAckWithTimeout(options.waitForAck, packet.packetId, timeoutSeconds);
       historyEntry.timestamps.acknowledged = ack.timestamp;
+      await this.historyStorage?.recordReceived({
+        packetId: packet.packetId,
+        eventAt: ack.timestamp,
+      });
       historyEntry.timestamps.completed = this.now().toISOString();
       historyEntry.status = ack.status === "accepted" ? "acknowledged" : "rejected";
       historyEntry.durationMs = this.toDurationMs(
         historyEntry.timestamps.created,
         historyEntry.timestamps.completed,
       );
+      if (ack.status === "accepted") {
+        await this.historyStorage?.recordAcknowledged({
+          packetId: packet.packetId,
+          eventAt: ack.timestamp,
+        });
+      } else {
+        await this.historyStorage?.recordRejected({
+          packetId: packet.packetId,
+          eventAt: ack.timestamp,
+        });
+      }
       if (ack.status === "rejected" && ack.reason) {
         historyEntry.error = ack.reason;
       }
@@ -107,6 +132,10 @@ export class HandoffManager {
           historyEntry.timestamps.created,
           historyEntry.timestamps.completed,
         );
+        await this.historyStorage?.recordExpired({
+          packetId: packet.packetId,
+          eventAt: historyEntry.timestamps.completed,
+        });
         this.history.push(historyEntry);
       }
       throw error;
@@ -120,6 +149,25 @@ export class HandoffManager {
     if (Number.isNaN(start) || Number.isNaN(end)) return undefined;
     return Math.max(0, end - start);
   }
+}
+
+function summarizeTask(task: Record<string, unknown>): string {
+  const summaryField = task["summary"];
+  if (typeof summaryField === "string" && summaryField.trim().length > 0) {
+    return summaryField;
+  }
+
+  const titleField = task["title"];
+  if (typeof titleField === "string" && titleField.trim().length > 0) {
+    return titleField;
+  }
+
+  const typeField = task["type"];
+  if (typeof typeField === "string" && typeField.trim().length > 0) {
+    return typeField;
+  }
+
+  return JSON.stringify(task).slice(0, 240);
 }
 
 export async function waitForAckWithTimeout(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,6 +180,20 @@ export {
   createMigrator,
   Migrator,
 } from "./db-migrations.js";
+export type {
+  HandoffHistoryQuery,
+  HandoffHistoryRecord,
+  HandoffHistoryStatus,
+  HandoffHistoryStorage,
+  HandoffRecordSentInput,
+  HandoffRecordStatusInput,
+} from "./handoff-history.js";
+export {
+  createHandoffHistoryStorage,
+  InMemoryHandoffHistoryStorage,
+  MIN_HANDOFF_HISTORY_RETENTION_MONTHS,
+  SqlHandoffHistoryStorage,
+} from "./handoff-history.js";
 export type { SendHandoffOptions, SendHandoffResult } from "./handoff-manager.js";
 export {
   HandoffManager,


### PR DESCRIPTION
## Summary
- add append-only handoff history storage (in-memory + SQL) for sent/received/acknowledged/expired/rejected packet lifecycle events
- add query filters for packetId, tool, status, and date range with minimum 24-month retention pruning guard
- integrate handoff lifecycle recording from HandoffManager into HAND-008 storage and audit trail entries
- expose new HAND-008 storage APIs from core index and add tests for lifecycle, querying, retention, SQL persistence, and audit integration

Closes #81