### PR TITLE
feat(core): support async handoff queue delivery (HAND-005)

### DIFF
--- a/packages/core/src/__tests__/handoff-manager.test.ts
+++ b/packages/core/src/__tests__/handoff-manager.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { InMemoryHandoffHistoryStorage } from "../handoff-history.js";
 import { HandoffManager, HandoffTimeoutError } from "../handoff-manager.js";
+import { createHandoffQueue } from "../handoff-queue.js";
 import type { ContextPacket } from "../handoff-schema.js";
 
 describe("handoff-manager (HAND-004)", () => {
@@ -112,6 +113,40 @@ describe("handoff-manager (HAND-004)", () => {
     expect(result.history.timestamps.sent).toBeDefined();
     expect(result.history.timestamps.acknowledged).toBe("2026-03-05T07:00:10Z");
     expect(result.history.timestamps.completed).toBeDefined();
+  });
+
+  it("queues delivery in async mode and returns queue record", async () => {
+    const handoffQueue = createHandoffQueue();
+    const manager = new HandoffManager({ handoffQueue });
+
+    const result = await manager.send(packet, {
+      sourceAgent: "sender-1",
+      targetAgent: "receiver-1",
+      mode: "async",
+    });
+
+    expect(result.status).toBe("sent");
+    expect(result.queueRecord).toMatchObject({
+      packetId: packet.packetId,
+      status: "queued",
+    });
+
+    const queuedStatus = await handoffQueue.getStatus(packet.packetId);
+    expect(queuedStatus?.status).toBe("queued");
+    expect(result.history.mode).toBe("async");
+    expect(result.history.status).toBe("sent");
+  });
+
+  it("requires a queue when mode is async", async () => {
+    const manager = new HandoffManager();
+
+    await expect(
+      manager.send(packet, {
+        sourceAgent: "sender-1",
+        targetAgent: "receiver-1",
+        mode: "async",
+      }),
+    ).rejects.toThrow(/handoffQueue is required for async handoff mode/i);
   });
 
   it("writes handoff lifecycle events into HAND-008 storage", async () => {

--- a/packages/core/src/handoff-manager.ts
+++ b/packages/core/src/handoff-manager.ts
@@ -1,4 +1,5 @@
 import type { HandoffHistoryStorage } from "./handoff-history.js";
+import type { HandoffQueue, HandoffQueueRecord } from "./handoff-queue.js";
 import type {
   ContextPacket,
   HandoffAck,
@@ -31,6 +32,7 @@ export interface SendHandoffOptions {
 export interface SendHandoffResult {
   status: "sent" | "acknowledged" | "rejected";
   ack?: HandoffAck;
+  queueRecord?: HandoffQueueRecord;
   history: HandoffHistoryEntry;
 }
 
@@ -38,10 +40,16 @@ export class HandoffManager {
   private readonly history: HandoffHistoryEntry[] = [];
   private readonly now: () => Date;
   private readonly historyStorage: HandoffHistoryStorage | undefined;
+  private readonly handoffQueue: HandoffQueue | undefined;
 
-  constructor(options?: { now?: () => Date; historyStorage?: HandoffHistoryStorage }) {
+  constructor(options?: {
+    now?: () => Date;
+    historyStorage?: HandoffHistoryStorage;
+    handoffQueue?: HandoffQueue;
+  }) {
     this.now = options?.now ?? (() => new Date());
     this.historyStorage = options?.historyStorage;
+    this.handoffQueue = options?.handoffQueue;
   }
 
   getHistory(): HandoffHistoryEntry[] {
@@ -77,13 +85,18 @@ export class HandoffManager {
     });
 
     if (mode === "async") {
+      if (!this.handoffQueue) {
+        throw new Error("handoffQueue is required for async handoff mode");
+      }
+
+      const queueRecord = await this.handoffQueue.enqueue(packet);
       historyEntry.timestamps.completed = this.now().toISOString();
       historyEntry.durationMs = this.toDurationMs(
         historyEntry.timestamps.created,
         historyEntry.timestamps.completed,
       );
       this.history.push(historyEntry);
-      return { status: "sent", history: historyEntry };
+      return { status: "sent", queueRecord, history: historyEntry };
     }
 
     if (!options.waitForAck) {


### PR DESCRIPTION
## Summary
- wire `HandoffManager` async mode to `HandoffQueue` so async sends are actually queued for delivery
- return queue metadata from `send()` for async handoffs (`queueRecord`)
- add tests for async queue delivery path and missing-queue error in async mode

## Validation
- `pnpm --filter @laup/core run typecheck`
- `pnpm run test:run -- packages/core/src/__tests__/handoff-manager.test.ts packages/core/src/__tests__/handoff-queue.test.ts`

Closes #78
