### PR TITLE
feat(core): maintain MCP registry audit trail for all operations

### DIFF
--- a/packages/core/src/__tests__/mcp-registry.test.ts
+++ b/packages/core/src/__tests__/mcp-registry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryMcpServerRegistry } from "../mcp-registry.js";
+
+describe("mcp-registry", () => {
+  const baseServer = {
+    id: "org/weather",
+    name: "Weather",
+    transport: "http" as const,
+    url: "https://example.com/mcp",
+    scope: "project" as const,
+    scopeId: "proj-1",
+    enabled: true,
+  };
+
+  it("records audit trail for registry operations", async () => {
+    const registry = new InMemoryMcpServerRegistry();
+    await registry.init();
+
+    await registry.register(baseServer, { actor: "alice" });
+    await registry.update({ ...baseServer, name: "Weather v2" }, { actor: "alice" });
+    await registry.disable(baseServer.id, { actor: "bob" }, "project", "proj-1");
+    await registry.enable(baseServer.id, { actor: "bob" }, "project", "proj-1");
+    await registry.rotateCredentials(
+      baseServer.id,
+      { key: "cred-2", type: "api-key" },
+      { actor: "carol" },
+      "project",
+      "proj-1",
+    );
+    await registry.deregister(baseServer.id, { actor: "alice" }, "project", "proj-1");
+
+    const entries = await registry.queryAudit();
+    expect(entries).toHaveLength(6);
+    expect(entries.map((entry) => entry.operation)).toEqual([
+      "register",
+      "update",
+      "disable",
+      "enable",
+      "credential-rotate",
+      "deregister",
+    ]);
+
+    for (const entry of entries) {
+      expect(entry.serverId).toBe(baseServer.id);
+      expect(entry.scope).toBe("project");
+      expect(entry.scopeId).toBe("proj-1");
+      expect(entry.actor.length).toBeGreaterThan(0);
+      expect(typeof entry.timestamp).toBe("string");
+    }
+  });
+
+  it("supports audit filtering and immutable records", async () => {
+    const registry = new InMemoryMcpServerRegistry();
+    await registry.init();
+
+    await registry.register(baseServer, { actor: "alice" });
+    await registry.update({ ...baseServer, name: "Weather v2" }, { actor: "bob" });
+
+    const byActor = await registry.queryAudit({ actor: "bob" });
+    expect(byActor).toHaveLength(1);
+    expect(byActor[0]?.operation).toBe("update");
+
+    const byOperation = await registry.queryAudit({ operation: "register" });
+    expect(byOperation).toHaveLength(1);
+
+    const byServer = await registry.queryAudit({ serverId: baseServer.id });
+    expect(byServer).toHaveLength(2);
+
+    const dateStart = new Date(Date.now() - 60_000).toISOString();
+    const dateEnd = new Date(Date.now() + 60_000).toISOString();
+    const byDate = await registry.queryAudit({ startTime: dateStart, endTime: dateEnd });
+    expect(byDate).toHaveLength(2);
+
+    const first = byServer[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+
+    first.actor = "mallory";
+
+    const freshRead = await registry.queryAudit({ operation: "register" });
+    expect(freshRead[0]?.actor).toBe("alice");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -298,6 +298,12 @@ export {
   measureMcpPropagationSlo,
 } from "./mcp-propagation.js";
 export type {
+  McpRegistryOperationOptions,
+  McpRegistryQuery,
+  McpServerRegistry,
+} from "./mcp-registry.js";
+export { InMemoryMcpServerRegistry } from "./mcp-registry.js";
+export type {
   McpAuditEntry,
   McpAuditOperation,
   McpCredentialRef,

--- a/packages/core/src/mcp-registry.ts
+++ b/packages/core/src/mcp-registry.ts
@@ -1,0 +1,277 @@
+import type {
+  McpAuditEntry,
+  McpAuditOperation,
+  McpCredentialRef,
+  McpScope,
+  McpServer,
+} from "./mcp-schema.js";
+import { validateMcpServer } from "./mcp-schema.js";
+
+export interface McpRegistryOperationOptions {
+  actor: string;
+  reason?: string;
+}
+
+export interface McpRegistryQuery {
+  serverId?: string;
+  actor?: string;
+  operation?: McpAuditOperation;
+  scope?: McpScope;
+  startTime?: string;
+  endTime?: string;
+}
+
+export interface McpServerRegistry {
+  init(): Promise<void>;
+  register(server: McpServer, options: McpRegistryOperationOptions): Promise<void>;
+  update(server: McpServer, options: McpRegistryOperationOptions): Promise<void>;
+  deregister(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void>;
+  enable(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void>;
+  disable(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void>;
+  rotateCredentials(
+    serverId: string,
+    credentials: McpCredentialRef,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void>;
+  list(): Promise<McpServer[]>;
+  get(serverId: string, scope?: McpScope, scopeId?: string): Promise<McpServer | null>;
+  queryAudit(filter?: McpRegistryQuery): Promise<McpAuditEntry[]>;
+}
+
+function registryKey(serverId: string, scope?: McpScope, scopeId?: string): string {
+  return `${scope ?? "project"}:${scopeId ?? ""}:${serverId}`;
+}
+
+function deepClone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+export class InMemoryMcpServerRegistry implements McpServerRegistry {
+  private readonly servers = new Map<string, McpServer>();
+  private readonly auditLog: McpAuditEntry[] = [];
+  private nextAuditId = 1;
+
+  async init(): Promise<void> {}
+
+  async register(server: McpServer, options: McpRegistryOperationOptions): Promise<void> {
+    const validated = this.validate(server);
+    const key = registryKey(validated.id, validated.scope, validated.scopeId);
+
+    if (this.servers.has(key)) {
+      throw new Error(`MCP server ${validated.id} already registered for scope ${validated.scope}`);
+    }
+
+    const now = new Date().toISOString();
+    const nextServer: McpServer = {
+      ...deepClone(validated),
+      registeredAt: validated.registeredAt ?? now,
+      updatedAt: now,
+    };
+
+    this.servers.set(key, nextServer);
+    this.recordAudit({
+      serverId: nextServer.id,
+      scope: nextServer.scope,
+      scopeId: nextServer.scopeId,
+      operation: "register",
+      actor: options.actor,
+      reason: options.reason,
+      newState: nextServer,
+    });
+  }
+
+  async update(server: McpServer, options: McpRegistryOperationOptions): Promise<void> {
+    const validated = this.validate(server);
+    const key = registryKey(validated.id, validated.scope, validated.scopeId);
+    const previous = this.servers.get(key);
+
+    if (!previous) {
+      throw new Error(`MCP server ${validated.id} not found`);
+    }
+
+    const nextServer: McpServer = {
+      ...deepClone(validated),
+      registeredAt: previous.registeredAt,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.servers.set(key, nextServer);
+    this.recordAudit({
+      serverId: nextServer.id,
+      scope: nextServer.scope,
+      scopeId: nextServer.scopeId,
+      operation: "update",
+      actor: options.actor,
+      reason: options.reason,
+      previousState: previous,
+      newState: nextServer,
+    });
+  }
+
+  async deregister(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void> {
+    const key = registryKey(serverId, scope, scopeId);
+    const previous = this.servers.get(key);
+    if (!previous) return;
+
+    this.servers.delete(key);
+    this.recordAudit({
+      serverId,
+      scope: previous.scope,
+      scopeId: previous.scopeId,
+      operation: "deregister",
+      actor: options.actor,
+      reason: options.reason,
+      previousState: previous,
+    });
+  }
+
+  async enable(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void> {
+    await this.setEnabled(serverId, true, options, scope, scopeId);
+  }
+
+  async disable(
+    serverId: string,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void> {
+    await this.setEnabled(serverId, false, options, scope, scopeId);
+  }
+
+  async rotateCredentials(
+    serverId: string,
+    credentials: McpCredentialRef,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void> {
+    const { key, previous } = this.requireServer(serverId, scope, scopeId);
+    const nextServer: McpServer = {
+      ...previous,
+      credentials: deepClone(credentials),
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.servers.set(key, nextServer);
+    this.recordAudit({
+      serverId,
+      scope: nextServer.scope,
+      scopeId: nextServer.scopeId,
+      operation: "credential-rotate",
+      actor: options.actor,
+      reason: options.reason,
+      previousState: previous,
+      newState: nextServer,
+    });
+  }
+
+  async list(): Promise<McpServer[]> {
+    return Array.from(this.servers.values()).map((server) => deepClone(server));
+  }
+
+  async get(serverId: string, scope?: McpScope, scopeId?: string): Promise<McpServer | null> {
+    const server = this.servers.get(registryKey(serverId, scope, scopeId));
+    return server ? deepClone(server) : null;
+  }
+
+  async queryAudit(filter?: McpRegistryQuery): Promise<McpAuditEntry[]> {
+    const start = filter?.startTime ? Date.parse(filter.startTime) : undefined;
+    const end = filter?.endTime ? Date.parse(filter.endTime) : undefined;
+
+    return this.auditLog
+      .filter((entry) => {
+        if (filter?.serverId && entry.serverId !== filter.serverId) return false;
+        if (filter?.actor && entry.actor !== filter.actor) return false;
+        if (filter?.operation && entry.operation !== filter.operation) return false;
+        if (filter?.scope && entry.scope !== filter.scope) return false;
+
+        const timestamp = Date.parse(entry.timestamp);
+        if (start !== undefined && !Number.isNaN(start) && timestamp < start) return false;
+        if (end !== undefined && !Number.isNaN(end) && timestamp > end) return false;
+
+        return true;
+      })
+      .map((entry) => deepClone(entry));
+  }
+
+  private validate(server: McpServer): McpServer {
+    const result = validateMcpServer(server);
+    if (!result.valid || !result.server) {
+      throw new Error(result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; "));
+    }
+    return result.server;
+  }
+
+  private async setEnabled(
+    serverId: string,
+    enabled: boolean,
+    options: McpRegistryOperationOptions,
+    scope?: McpScope,
+    scopeId?: string,
+  ): Promise<void> {
+    const { key, previous } = this.requireServer(serverId, scope, scopeId);
+    const nextServer: McpServer = {
+      ...previous,
+      enabled,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.servers.set(key, nextServer);
+    this.recordAudit({
+      serverId,
+      scope: nextServer.scope,
+      scopeId: nextServer.scopeId,
+      operation: enabled ? "enable" : "disable",
+      actor: options.actor,
+      reason: options.reason,
+      previousState: previous,
+      newState: nextServer,
+    });
+  }
+
+  private requireServer(serverId: string, scope?: McpScope, scopeId?: string) {
+    const key = registryKey(serverId, scope, scopeId);
+    const previous = this.servers.get(key);
+    if (!previous) {
+      throw new Error(`MCP server ${serverId} not found`);
+    }
+    return { key, previous };
+  }
+
+  private recordAudit(input: Omit<McpAuditEntry, "id" | "timestamp">): void {
+    const entry: McpAuditEntry = Object.freeze({
+      id: `mcp_audit_${this.nextAuditId++}`,
+      timestamp: new Date().toISOString(),
+      ...deepClone(input),
+    });
+
+    this.auditLog.push(entry);
+  }
+}

--- a/packages/core/src/mcp-schema.ts
+++ b/packages/core/src/mcp-schema.ts
@@ -316,6 +316,7 @@ export const McpAuditOperationSchema = z.enum([
   "deregister",
   "enable",
   "disable",
+  "credential-rotate",
   "health-change",
 ]);
 
@@ -333,6 +334,12 @@ export const McpAuditEntrySchema = z.object({
 
   /** Operation type */
   operation: McpAuditOperationSchema,
+
+  /** Scope level */
+  scope: McpScopeSchema,
+
+  /** Scope identifier */
+  scopeId: z.string().optional(),
 
   /** User/agent that performed the operation */
   actor: z.string(),


### PR DESCRIPTION
## Summary
- add `InMemoryMcpServerRegistry` with auditable MCP registry operations (register/update/deregister/enable/disable/credential rotation)
- capture immutable audit records with actor, timestamp, scope, operation type, and server ID
- add audit querying by server ID, actor, operation type, scope, and date range
- extend MCP audit schema with `credential-rotate` operation and explicit scope fields
- add focused tests for registry audit logging and query behavior

## Validation
- `pnpm --filter @laup/core typecheck`
- `pnpm test:run -- --reporter=dot packages/core/src/__tests__/mcp-schema.test.ts packages/core/src/__tests__/mcp-registry.test.ts packages/core/src/__tests__/mcp-health-monitor.test.ts packages/core/src/__tests__/mcp-propagation.test.ts packages/core/src/__tests__/mcp-versioning.test.ts`

Closes #91
