### PR TITLE
feat(core): graceful MCP deregistration with orphan checks

### DIFF
--- a/packages/core/src/__tests__/mcp-registry.test.ts
+++ b/packages/core/src/__tests__/mcp-registry.test.ts
@@ -80,4 +80,34 @@ describe("mcp-registry", () => {
     const freshRead = await registry.queryAudit({ operation: "register" });
     expect(freshRead[0]?.actor).toBe("alice");
   });
+
+  it("blocks deregistration when orphaned references exist", async () => {
+    const registry = new InMemoryMcpServerRegistry();
+    await registry.init();
+    await registry.register(baseServer, { actor: "alice" });
+
+    await expect(
+      registry.deregister(baseServer.id, { actor: "alice" }, "project", "proj-1", async () => ({
+        safe: false,
+        references: [{ type: "tool", id: "cursor", name: "Cursor" }],
+      })),
+    ).rejects.toThrow("orphaned references");
+
+    expect(await registry.get(baseServer.id, "project", "proj-1")).not.toBeNull();
+    expect(await registry.queryAudit({ operation: "deregister" })).toHaveLength(0);
+  });
+
+  it("supports graceful deregistration with orphan check", async () => {
+    const registry = new InMemoryMcpServerRegistry();
+    await registry.init();
+    await registry.register(baseServer, { actor: "alice" });
+
+    await registry.deregister(baseServer.id, { actor: "alice" }, "project", "proj-1", async () => ({
+      safe: true,
+      references: [],
+    }));
+
+    expect(await registry.get(baseServer.id, "project", "proj-1")).toBeNull();
+    expect(await registry.queryAudit({ operation: "deregister" })).toHaveLength(1);
+  });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -298,6 +298,7 @@ export {
   measureMcpPropagationSlo,
 } from "./mcp-propagation.js";
 export type {
+  McpOrphanCheck,
   McpRegistryOperationOptions,
   McpRegistryQuery,
   McpServerRegistry,

--- a/packages/core/src/mcp-registry.ts
+++ b/packages/core/src/mcp-registry.ts
@@ -4,6 +4,7 @@ import type {
   McpCredentialRef,
   McpScope,
   McpServer,
+  OrphanCheckResult,
 } from "./mcp-schema.js";
 import { validateMcpServer } from "./mcp-schema.js";
 
@@ -21,6 +22,10 @@ export interface McpRegistryQuery {
   endTime?: string;
 }
 
+export type McpOrphanCheck =
+  | ((server: McpServer) => OrphanCheckResult | Promise<OrphanCheckResult>)
+  | undefined;
+
 export interface McpServerRegistry {
   init(): Promise<void>;
   register(server: McpServer, options: McpRegistryOperationOptions): Promise<void>;
@@ -30,6 +35,7 @@ export interface McpServerRegistry {
     options: McpRegistryOperationOptions,
     scope?: McpScope,
     scopeId?: string,
+    orphanCheck?: McpOrphanCheck,
   ): Promise<void>;
   enable(
     serverId: string,
@@ -130,10 +136,19 @@ export class InMemoryMcpServerRegistry implements McpServerRegistry {
     options: McpRegistryOperationOptions,
     scope?: McpScope,
     scopeId?: string,
+    orphanCheck?: McpOrphanCheck,
   ): Promise<void> {
     const key = registryKey(serverId, scope, scopeId);
     const previous = this.servers.get(key);
     if (!previous) return;
+
+    if (orphanCheck) {
+      const result = await orphanCheck(deepClone(previous));
+      if (!result.safe) {
+        const refs = result.references.map((ref) => `${ref.type}:${ref.id}`).join(", ");
+        throw new Error(`Cannot deregister MCP server ${serverId}; orphaned references: ${refs}`);
+      }
+    }
 
     this.servers.delete(key);
     this.recordAudit({


### PR DESCRIPTION
## Summary
- add optional `orphanCheck` hook to `McpServerRegistry.deregister` to support graceful deregistration workflows
- block deregistration when unresolved references are reported, preventing orphaned tool references
- keep existing MCP audit behavior (successful deregistration still records `deregister` entries)
- export `McpOrphanCheck` from core index
- add registry tests for blocked and successful graceful deregistration

## Validation
- `pnpm --filter @laup/core run typecheck`
- `pnpm test:run packages/core/src/__tests__/mcp-registry.test.ts packages/core/src/__tests__/mcp-propagation.test.ts packages/core/src/__tests__/mcp-schema.test.ts`

Closes #92
