### PR TITLE
feat(core): configurable budget alerts with percentage and projection support

### DIFF
--- a/packages/core/src/__tests__/cost-schema.test.ts
+++ b/packages/core/src/__tests__/cost-schema.test.ts
@@ -8,11 +8,13 @@ import {
   aggregateUsageBySkill,
   aggregateUsageByTeam,
   type BudgetAlert,
+  BudgetAlertSchema,
   type CostCap,
   calculateLlmCost,
   isCostCapExceeded,
   type LlmUsage,
   type ModelPricing,
+  projectPeriodCost,
   shouldFireAlert,
   type UsageEvent,
 } from "../cost-schema.js";
@@ -145,6 +147,75 @@ describe("cost-schema", () => {
     it("returns false when alert is disabled", () => {
       const disabledAlert = { ...alert, enabled: false };
       expect(shouldFireAlert(100, disabledAlert)).toBe(false);
+    });
+
+    it("supports percentage-based thresholds against configured budget", () => {
+      const percentageAlert: BudgetAlert = {
+        id: "alert-2",
+        name: "Budget Percent Alert",
+        budget: 200,
+        percentages: [75, 90, 100],
+        period: "monthly",
+        recipients: ["finance@example.com"],
+        enabled: true,
+        channels: ["email", "slack"],
+      };
+
+      expect(shouldFireAlert(149, percentageAlert)).toBe(false);
+      expect(shouldFireAlert(150, percentageAlert)).toBe(true);
+    });
+
+    it("supports projected spend alerts using current spend rate", () => {
+      const projectedAlert: BudgetAlert = {
+        id: "alert-3",
+        name: "Projected Overrun Alert",
+        budget: 100,
+        percentages: [100],
+        projected: true,
+        period: "monthly",
+        recipients: ["ops@example.com"],
+        enabled: true,
+        channels: ["email"],
+      };
+
+      // $10 spent in first 10% of period projects to $100 total by period end.
+      expect(shouldFireAlert(10, projectedAlert, { elapsedMs: 10, periodMs: 100 })).toBe(true);
+    });
+
+    it("projects period cost from spend rate", () => {
+      expect(projectPeriodCost(10, 10, 100)).toBe(100);
+      expect(projectPeriodCost(10, 0, 100)).toBe(10);
+    });
+
+    it("validates attribution dimension + value pairing", () => {
+      expect(
+        BudgetAlertSchema.safeParse({
+          id: "alert-4",
+          name: "Team Budget Alert",
+          budget: 100,
+          percentages: [100],
+          period: "monthly",
+          recipients: ["ops@example.com"],
+          enabled: true,
+          channels: ["email", "slack"],
+          attributionDimension: "teamId",
+          attributionValue: "team-1",
+        }).success,
+      ).toBe(true);
+
+      expect(
+        BudgetAlertSchema.safeParse({
+          id: "alert-5",
+          name: "Invalid Team Alert",
+          budget: 100,
+          percentages: [100],
+          period: "monthly",
+          recipients: ["ops@example.com"],
+          enabled: true,
+          channels: ["email"],
+          attributionDimension: "teamId",
+        }).success,
+      ).toBe(false);
     });
   });
 

--- a/packages/core/src/cost-schema.ts
+++ b/packages/core/src/cost-schema.ts
@@ -241,31 +241,75 @@ export type ModelPricing = z.infer<typeof ModelPricingSchema>;
 /**
  * Budget alert configuration (COST-004).
  */
-export const BudgetAlertSchema = z.object({
-  /** Alert ID */
-  id: z.string(),
+export const BudgetAlertSchema = z
+  .object({
+    /** Alert ID */
+    id: z.string(),
 
-  /** Alert name */
-  name: z.string(),
+    /** Alert name */
+    name: z.string(),
 
-  /** Threshold amount (USD) */
-  threshold: z.number().positive(),
+    /** Optional absolute threshold amount (USD) */
+    threshold: z.number().positive().optional(),
 
-  /** Time period */
-  period: z.enum(["daily", "weekly", "monthly", "quarterly", "yearly"]),
+    /** Configured budget amount for percentage-based alerts (USD) */
+    budget: z.number().positive().optional(),
 
-  /** Attribution filter */
-  filter: UsageAttributionSchema.optional(),
+    /** Alert trigger percentages of budget (e.g., 75, 90, 100) */
+    percentages: z.array(z.number().gt(0).lte(100)).min(1).optional(),
 
-  /** Alert recipients */
-  recipients: z.array(z.string()),
+    /** Whether projected spend should be used for trigger evaluation */
+    projected: z.boolean().optional(),
 
-  /** Whether alert is enabled */
-  enabled: z.boolean().default(true),
+    /** Time period */
+    period: z.enum(["daily", "weekly", "monthly", "quarterly", "yearly"]),
 
-  /** Notification channels */
-  channels: z.array(z.enum(["email", "slack", "webhook"])).default(["email"]),
-});
+    /** Optional attribution target (COST-004): developer/team/project */
+    attributionDimension: z.enum(["developerId", "teamId", "projectId"]).optional(),
+
+    /** Attribution value for the configured dimension */
+    attributionValue: z.string().optional(),
+
+    /** Attribution filter */
+    filter: UsageAttributionSchema.optional(),
+
+    /** Alert recipients */
+    recipients: z.array(z.string()),
+
+    /** Whether alert is enabled */
+    enabled: z.boolean().default(true),
+
+    /** Notification channels (PERM-017) */
+    channels: z.array(z.enum(["email", "slack", "webhook"])).default(["email"]),
+  })
+  .superRefine((value, ctx) => {
+    if (value.attributionDimension && !value.attributionValue) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "attributionValue is required when attributionDimension is configured",
+        path: ["attributionValue"],
+      });
+    }
+
+    if (value.attributionValue && !value.attributionDimension) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "attributionDimension is required when attributionValue is configured",
+        path: ["attributionDimension"],
+      });
+    }
+
+    const hasAbsoluteThreshold = value.threshold !== undefined;
+    const hasPercentageThreshold = value.budget !== undefined;
+
+    if (!hasAbsoluteThreshold && !hasPercentageThreshold) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Either threshold or budget must be configured",
+        path: ["threshold"],
+      });
+    }
+  });
 
 export type BudgetAlert = z.infer<typeof BudgetAlertSchema>;
 
@@ -371,10 +415,42 @@ export function isCostCapExceeded(currentCost: number, cap: CostCap): boolean {
 }
 
 /**
+ * Project end-of-period cost from current spend and elapsed period time.
+ */
+export function projectPeriodCost(
+  currentCost: number,
+  elapsedMs: number,
+  periodMs: number,
+): number {
+  if (elapsedMs <= 0 || periodMs <= 0) return currentCost;
+  return (currentCost / elapsedMs) * periodMs;
+}
+
+/**
  * Check if a budget alert should fire.
  */
-export function shouldFireAlert(currentCost: number, alert: BudgetAlert): boolean {
-  return alert.enabled && currentCost >= alert.threshold;
+export function shouldFireAlert(
+  currentCost: number,
+  alert: BudgetAlert,
+  options?: { elapsedMs?: number; periodMs?: number },
+): boolean {
+  if (!alert.enabled) return false;
+
+  const evaluationCost =
+    alert.projected && options?.elapsedMs && options?.periodMs
+      ? projectPeriodCost(currentCost, options.elapsedMs, options.periodMs)
+      : currentCost;
+
+  if (alert.threshold !== undefined && evaluationCost >= alert.threshold) {
+    return true;
+  }
+
+  if (alert.budget !== undefined) {
+    const percentages = alert.percentages?.length ? alert.percentages : [100];
+    return percentages.some((percentage) => evaluationCost >= alert.budget! * (percentage / 100));
+  }
+
+  return false;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,6 +123,7 @@ export {
   McpInvocationUsageSchema,
   MemoryOperationUsageSchema,
   ModelPricingSchema,
+  projectPeriodCost,
   SkillInvocationUsageSchema,
   shouldFireAlert,
   UsageAttributionSchema,


### PR DESCRIPTION
## Summary
- extend `BudgetAlert` to support configurable percentage thresholds over a configured budget
- add optional attribution targeting (`developerId`, `teamId`, `projectId`) for per-dimension alert configuration
- support projected budget alert evaluation via spend-rate projection with `projectPeriodCost`
- keep existing absolute-threshold behavior for backward compatibility
- export `projectPeriodCost` from core index and add tests for percentage, projection, and schema validation

## Validation
- `pnpm --filter @laup/core typecheck`
- `pnpm test:run packages/core/src/__tests__/cost-schema.test.ts`
- `pnpm test:run packages/core/src/__tests__`

Closes #99
