### PR TITLE
feat(core): support cost anomaly detection (COST-008)

### DIFF
--- a/packages/core/src/__tests__/cost-anomaly.test.ts
+++ b/packages/core/src/__tests__/cost-anomaly.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryAuditStorage } from "../audit-storage.js";
+import { CostAnomalyDetector } from "../cost-anomaly.js";
+import type { UsageEvent } from "../cost-schema.js";
+import { InMemoryUsageStorage } from "../usage-storage.js";
+
+describe("CostAnomalyDetector", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-03T18:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("detects developer and project token spikes against rolling historical baseline", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const auditStorage = new InMemoryAuditStorage();
+    await auditStorage.init();
+
+    for (let hour = 24; hour >= 1; hour -= 1) {
+      const timestamp = new Date(Date.parse("2026-03-03T18:00:00.000Z") - hour * 60 * 60_000);
+      await store(usageStorage, timestamp.toISOString(), {
+        developerId: "dev-1",
+        projectId: "proj-1",
+        inputTokens: 50,
+        outputTokens: 50,
+      });
+    }
+
+    await store(usageStorage, "2026-03-03T17:50:00.000Z", {
+      developerId: "dev-1",
+      projectId: "proj-1",
+      inputTokens: 300,
+      outputTokens: 300,
+    });
+
+    const detector = new CostAnomalyDetector({
+      usageStorage,
+      auditStorage,
+      now: () => new Date(),
+    });
+
+    const report = await detector.detect();
+
+    expect(report.anomalies).toHaveLength(2);
+    expect(report.anomalies.map((anomaly) => anomaly.dimension).sort()).toEqual([
+      "developerId",
+      "projectId",
+    ]);
+
+    expect(report.anomalies[0]?.ratio).toBeGreaterThanOrEqual(6);
+
+    const auditPage = await auditStorage.query({ action: "cost.anomaly.detected" }, 20, 0);
+    expect(auditPage.total).toBe(2);
+    expect(auditPage.entries[0]?.targetType).toBe("cost-anomaly");
+  });
+
+  it("supports configurable threshold, detection window, and notification channels", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const auditStorage = new InMemoryAuditStorage();
+    await auditStorage.init();
+
+    const sender = vi.fn(async () => {});
+
+    for (let window = 4; window >= 1; window -= 1) {
+      const timestamp = new Date(Date.parse("2026-03-03T18:00:00.000Z") - window * 30 * 60_000);
+      await store(usageStorage, timestamp.toISOString(), {
+        developerId: "dev-2",
+        projectId: "proj-2",
+        inputTokens: 50,
+        outputTokens: 50,
+      });
+    }
+
+    await store(usageStorage, "2026-03-03T17:55:00.000Z", {
+      developerId: "dev-2",
+      projectId: "proj-2",
+      inputTokens: 100,
+      outputTokens: 100,
+    });
+
+    const detector = new CostAnomalyDetector({
+      usageStorage,
+      auditStorage,
+      detectionWindowMs: 30 * 60_000,
+      baselineWindowCount: 4,
+      thresholdMultiplier: 1.5,
+      dimensions: ["developerId"],
+      channels: ["email", "slack"],
+      notificationSender: sender,
+      now: () => new Date(),
+    });
+
+    const report = await detector.detect();
+
+    expect(report.anomalies).toHaveLength(1);
+    expect(report.anomalies[0]?.subject).toBe("dev-2");
+    expect(sender).toHaveBeenCalledTimes(2);
+    expect(sender).toHaveBeenNthCalledWith(1, "email", report.anomalies[0]);
+    expect(sender).toHaveBeenNthCalledWith(2, "slack", report.anomalies[0]);
+  });
+});
+
+async function store(
+  storage: InMemoryUsageStorage,
+  timestamp: string,
+  data: {
+    developerId: string;
+    projectId: string;
+    inputTokens: number;
+    outputTokens: number;
+  },
+): Promise<void> {
+  const event: UsageEvent = {
+    id: `evt_${timestamp}`,
+    timestamp,
+    type: "llm-call",
+    attribution: {
+      developerId: data.developerId,
+      projectId: data.projectId,
+    },
+    data: {
+      provider: "openai",
+      model: "gpt-4o-mini",
+      inputTokens: data.inputTokens,
+      outputTokens: data.outputTokens,
+      durationMs: 100,
+      success: true,
+    },
+  };
+
+  await storage.store(event);
+}

--- a/packages/core/src/cost-anomaly.ts
+++ b/packages/core/src/cost-anomaly.ts
@@ -1,0 +1,266 @@
+import { z } from "zod";
+import type { AuditSeverity, AuditStorage } from "./audit-storage.js";
+import type { UsageStorage } from "./usage-storage.js";
+
+export const CostAnomalyDimensionSchema = z.enum(["developerId", "projectId"]);
+export type CostAnomalyDimension = z.infer<typeof CostAnomalyDimensionSchema>;
+
+export const CostAnomalyChannelSchema = z.enum(["email", "slack", "webhook"]);
+export type CostAnomalyChannel = z.infer<typeof CostAnomalyChannelSchema>;
+
+export const CostAnomalySchema = z.object({
+  id: z.string(),
+  detectedAt: z.string(),
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  dimension: CostAnomalyDimensionSchema,
+  subject: z.string(),
+  currentTokens: z.number().int().nonnegative(),
+  baselineTokens: z.number().nonnegative(),
+  ratio: z.number().nonnegative(),
+  thresholdMultiplier: z.number().positive(),
+  severity: z.enum(["warning", "critical"]),
+});
+
+export type CostAnomaly = z.infer<typeof CostAnomalySchema>;
+
+export const CostAnomalyDetectionReportSchema = z.object({
+  generatedAt: z.string(),
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  baselineStart: z.string(),
+  baselineEnd: z.string(),
+  thresholdMultiplier: z.number().positive(),
+  detectionWindowMs: z.number().int().positive(),
+  baselineWindowCount: z.number().int().positive(),
+  anomalies: z.array(CostAnomalySchema),
+});
+
+export type CostAnomalyDetectionReport = z.infer<typeof CostAnomalyDetectionReportSchema>;
+
+export interface CostAnomalyDetectorConfig {
+  usageStorage: UsageStorage;
+  auditStorage: AuditStorage;
+  detectionWindowMs?: number;
+  baselineWindowCount?: number;
+  thresholdMultiplier?: number;
+  dimensions?: CostAnomalyDimension[];
+  channels?: CostAnomalyChannel[];
+  notificationSender?: (channel: CostAnomalyChannel, anomaly: CostAnomaly) => Promise<void> | void;
+  now?: () => Date;
+}
+
+const DEFAULT_DETECTION_WINDOW_MS = 60 * 60_000;
+const DEFAULT_BASELINE_WINDOW_COUNT = 24;
+const DEFAULT_THRESHOLD_MULTIPLIER = 5;
+const DEFAULT_DIMENSIONS: CostAnomalyDimension[] = ["developerId", "projectId"];
+const DEFAULT_CHANNELS: CostAnomalyChannel[] = ["email"];
+
+export class CostAnomalyDetector {
+  private readonly now: () => Date;
+  private readonly detectionWindowMs: number;
+  private readonly baselineWindowCount: number;
+  private readonly thresholdMultiplier: number;
+  private readonly dimensions: CostAnomalyDimension[];
+  private readonly channels: CostAnomalyChannel[];
+
+  constructor(private readonly config: CostAnomalyDetectorConfig) {
+    this.now = config.now ?? (() => new Date());
+    this.detectionWindowMs = positiveInt(config.detectionWindowMs, DEFAULT_DETECTION_WINDOW_MS);
+    this.baselineWindowCount = positiveInt(
+      config.baselineWindowCount,
+      DEFAULT_BASELINE_WINDOW_COUNT,
+    );
+    this.thresholdMultiplier = config.thresholdMultiplier ?? DEFAULT_THRESHOLD_MULTIPLIER;
+    if (this.thresholdMultiplier <= 0) {
+      throw new Error("thresholdMultiplier must be positive");
+    }
+
+    this.dimensions = uniqueDimensions(config.dimensions ?? DEFAULT_DIMENSIONS);
+    this.channels = uniqueChannels(config.channels ?? DEFAULT_CHANNELS);
+  }
+
+  async detect(): Promise<CostAnomalyDetectionReport> {
+    const endTime = this.now();
+    const windowStart = new Date(endTime.getTime() - this.detectionWindowMs);
+    const baselineStart = new Date(
+      windowStart.getTime() - this.detectionWindowMs * this.baselineWindowCount,
+    );
+
+    const events = await this.loadEvents(baselineStart, endTime);
+    const anomalies = this.findAnomalies(events, baselineStart, windowStart, endTime);
+
+    for (const anomaly of anomalies) {
+      await this.config.auditStorage.append({
+        category: "data",
+        action: "cost.anomaly.detected",
+        actor: "system",
+        targetId: `${anomaly.dimension}:${anomaly.subject}`,
+        targetType: "cost-anomaly",
+        severity: anomaly.severity as AuditSeverity,
+        metadata: {
+          ...anomaly,
+          channels: this.channels,
+        },
+      });
+
+      if (this.config.notificationSender) {
+        for (const channel of this.channels) {
+          await this.config.notificationSender(channel, anomaly);
+        }
+      }
+    }
+
+    return {
+      generatedAt: endTime.toISOString(),
+      windowStart: windowStart.toISOString(),
+      windowEnd: endTime.toISOString(),
+      baselineStart: baselineStart.toISOString(),
+      baselineEnd: windowStart.toISOString(),
+      thresholdMultiplier: this.thresholdMultiplier,
+      detectionWindowMs: this.detectionWindowMs,
+      baselineWindowCount: this.baselineWindowCount,
+      anomalies,
+    };
+  }
+
+  private async loadEvents(startTime: Date, endTime: Date) {
+    const pageSize = 500;
+    let offset = 0;
+    const events: Awaited<ReturnType<UsageStorage["query"]>>["data"] = [];
+
+    while (true) {
+      const page = await this.config.usageStorage.query(
+        { startTime, endTime },
+        { limit: pageSize, offset },
+      );
+      events.push(...page.data);
+
+      if (!page.hasMore) break;
+      offset += pageSize;
+    }
+
+    return events;
+  }
+
+  private findAnomalies(
+    events: Awaited<ReturnType<UsageStorage["query"]>>["data"],
+    baselineStart: Date,
+    windowStart: Date,
+    windowEnd: Date,
+  ): CostAnomaly[] {
+    const anomalies: CostAnomaly[] = [];
+
+    for (const dimension of this.dimensions) {
+      const subjects = collectSubjects(events, dimension);
+
+      for (const subject of subjects) {
+        const currentTokens = tokenTotalForRange(
+          events,
+          dimension,
+          subject,
+          windowStart,
+          windowEnd,
+        );
+        const baselineTotal = tokenTotalForRange(
+          events,
+          dimension,
+          subject,
+          baselineStart,
+          windowStart,
+        );
+        const baselineTokens = baselineTotal / this.baselineWindowCount;
+
+        if (baselineTokens <= 0) {
+          continue;
+        }
+
+        const ratio = currentTokens / baselineTokens;
+        if (ratio < this.thresholdMultiplier) {
+          continue;
+        }
+
+        anomalies.push({
+          id: `${dimension}:${subject}:${windowEnd.toISOString()}`,
+          detectedAt: windowEnd.toISOString(),
+          windowStart: windowStart.toISOString(),
+          windowEnd: windowEnd.toISOString(),
+          dimension,
+          subject,
+          currentTokens,
+          baselineTokens,
+          ratio,
+          thresholdMultiplier: this.thresholdMultiplier,
+          severity: ratio >= this.thresholdMultiplier * 2 ? "critical" : "warning",
+        });
+      }
+    }
+
+    return anomalies.sort((a, b) => a.id.localeCompare(b.id));
+  }
+}
+
+export function createCostAnomalyDetector(config: CostAnomalyDetectorConfig): CostAnomalyDetector {
+  return new CostAnomalyDetector(config);
+}
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  const normalized = value ?? fallback;
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throw new Error("Expected positive integer configuration value");
+  }
+  return normalized;
+}
+
+function uniqueDimensions(dimensions: CostAnomalyDimension[]): CostAnomalyDimension[] {
+  return Array.from(
+    new Set(dimensions.map((dimension) => CostAnomalyDimensionSchema.parse(dimension))),
+  );
+}
+
+function uniqueChannels(channels: CostAnomalyChannel[]): CostAnomalyChannel[] {
+  return Array.from(new Set(channels.map((channel) => CostAnomalyChannelSchema.parse(channel))));
+}
+
+function collectSubjects(
+  events: Awaited<ReturnType<UsageStorage["query"]>>["data"],
+  dimension: CostAnomalyDimension,
+): string[] {
+  const values = new Set<string>();
+  for (const event of events) {
+    const value = event.attribution[dimension] ?? "unknown";
+    values.add(value);
+  }
+  return Array.from(values.values());
+}
+
+function tokenTotalForRange(
+  events: Awaited<ReturnType<UsageStorage["query"]>>["data"],
+  dimension: CostAnomalyDimension,
+  subject: string,
+  start: Date,
+  end: Date,
+): number {
+  let total = 0;
+
+  for (const event of events) {
+    const timestamp = Date.parse(event.timestamp);
+    if (timestamp < start.getTime() || timestamp >= end.getTime()) {
+      continue;
+    }
+
+    const eventSubject = event.attribution[dimension] ?? "unknown";
+    if (eventSubject !== subject) {
+      continue;
+    }
+
+    if (event.type !== "llm-call") {
+      continue;
+    }
+
+    const usage = event.data as { inputTokens: number; outputTokens: number };
+    total += usage.inputTokens + usage.outputTokens;
+  }
+
+  return total;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,20 @@ export {
   serializeCursorContextForTransport,
 } from "./context-packet-serializers.js";
 export type {
+  CostAnomaly,
+  CostAnomalyChannel,
+  CostAnomalyDetectionReport,
+  CostAnomalyDimension,
+} from "./cost-anomaly.js";
+export {
+  CostAnomalyChannelSchema,
+  CostAnomalyDetectionReportSchema,
+  CostAnomalyDetector,
+  CostAnomalyDimensionSchema,
+  CostAnomalySchema,
+  createCostAnomalyDetector,
+} from "./cost-anomaly.js";
+export type {
   FallbackPricing,
   LlmCostBreakdown,
   MissingPriceStrategy,


### PR DESCRIPTION
## Summary\n- add  with rolling-baseline detection for developer/project token anomalies\n- default detection window is 1 hour with configurable threshold multiplier (default 5x) and baseline window count\n- emit anomaly alerts via configurable PERM-017 channels (, , ) through pluggable sender\n- record each anomaly to audit log as \n- export new detector/types/schemas from \n\n## Tests\n- add unit tests for baseline anomaly detection + audit logging\n- add unit test for configurable threshold/window/channel notifications\n- run 
> @laup/core@0.0.0 typecheck /home/otterammo/.openclaw/workspace/laup/packages/core
> tsc --noEmit\n- run 
> laup@0.0.0 test:run /home/otterammo/.openclaw/workspace/laup
> vitest run "--" "packages/core/src/__tests__/cost-anomaly.test.ts" "packages/core/src/__tests__/cost-dashboard.test.ts"


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/home/otterammo/.openclaw/workspace/laup[39m

 [32m✓[39m packages/core/src/__tests__/cache.test.ts [2m([22m[2m31 tests[22m[2m)[22m[32m 224[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/audit-storage.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 104[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/index.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 97[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/job-queue.test.ts [2m([22m[2m21 tests[22m[2m)[22m[33m 1076[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/api-server.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 93[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/memory-store.semantic.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 55[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/skill-schema.test.ts [2m([22m[2m68 tests[22m[2m)[22m[32m 88[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/hierarchy.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 48[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/memory-store.test.ts [2m([22m[2m21 tests[22m[2m)[22m[32m 57[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/context-packet-serializers.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 46[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/mcp-schema.test.ts [2m([22m[2m28 tests[22m[2m)[22m[32m 56[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/policy-evaluator.test.ts [2m([22m[2m59 tests[22m[2m)[22m[32m 60[2mms[22m[39m
 [32m✓[39m packages/adapters/cursor/src/__tests__/index.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/policy-as-code.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/memory-zep.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/db-migrations.test.ts [2m([22m[2m19 tests[22m[2m | [22m[33m1 skipped[39m[2m)[22m[32m 38[2mms[22m[39m
 [32m✓[39m packages/adapters/aider/src/__tests__/index.test.ts [2m([22m[2m21 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/handoff-schema.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/scope-loader.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/permission-anomaly.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 42[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/compliance-reporting.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 37[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/handoff-manager.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/marketplace.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/index.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/approval-gate.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/usage-storage.test.ts [2m([22m[2m19 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/include.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m packages/adapters/opencode/src/__tests__/index.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 34[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/rate-limiter.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/cost-anomaly.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/credential-store.test.ts [2m([22m[2m36 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/cost-schema.test.ts [2m([22m[2m26 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/resource-guard.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/memory-store.export.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 41[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/policy-simulation.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 101[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/handoff-history.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 48[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/action-hooks.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 43[2mms[22m[39m
 [32m✓[39m packages/adapters/claude-code/src/__tests__/index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/data-export.test.ts [2m([22m[2m26 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/mcp-propagation.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/policy-notifications.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/memory-mem0.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/usage-collector.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/skill-version.test.ts [2m([22m[2m25 tests[22m[2m)[22m[32m 19[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/mcp-registry.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/import.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/skill-registry.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m packages/adapters/copilot/src/__tests__/index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 28[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/query-builder.test.ts [2m([22m[2m25 tests[22m[2m)[22m[32m 20[2mms[22m[39m
 [32m✓[39m packages/adapters/codex/src/__tests__/index.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/db-adapter.test.ts [2m([22m[2m15 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/kill-switch.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/crud.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 23[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/cost-dashboard.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/skill-renderer.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/mcp-health-monitor.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/policy-schema.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/permission-audit.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/security-dashboard.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/action-taxonomy.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/skill-history.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/policy/rbac.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/scope.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/webhooks.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/handoff-queue.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/mcp-versioning.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/cost-conversion.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/auth/auth-middleware.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/auto-merge.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m packages/core/src/__tests__/handoff-routing.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/optimistic-locking.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m packages/config-hub/src/__tests__/audit-history.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m packages/cli/src/__tests__/index.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m

[2m Test Files [22m [1m[32m73 passed[39m[22m[90m (73)[39m
[2m      Tests [22m [1m[32m877 passed[39m[22m[2m | [22m[33m1 skipped[39m[90m (878)[39m
[2m   Start at [22m 04:11:19
[2m   Duration [22m 10.90s[2m (transform 3.40s, setup 0ms, import 12.83s, tests 3.59s, environment 15ms)[22m\n\nCloses #103