### PR TITLE
feat(core): add per-skill cost attribution report (COST-009)

### DIFF
--- a/packages/core/src/__tests__/cost-attribution-report.test.ts
+++ b/packages/core/src/__tests__/cost-attribution-report.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { CostAttributionReportService } from "../cost-attribution-report.js";
+import type { UsageEvent } from "../cost-schema.js";
+import { InMemoryPricingProvider } from "../pricing-provider.js";
+import { InMemoryUsageStorage } from "../usage-storage.js";
+
+describe("CostAttributionReportService", () => {
+  it("generates per-skill token + cost report filtered by range, project, and team", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const pricingProvider = new InMemoryPricingProvider({
+      initialPricing: [
+        {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          inputCostPerMillion: 1,
+          outputCostPerMillion: 2,
+          effectiveDate: "2026-01-01",
+          currency: "USD",
+        },
+      ],
+    });
+
+    await usageStorage.store(
+      createLlmEvent("evt-1", "2026-03-01T10:00:00.000Z", {
+        skillId: "acme/review",
+        teamId: "team-1",
+        projectId: "proj-1",
+        inputTokens: 1_000,
+        outputTokens: 1_000,
+      }),
+    );
+    await usageStorage.store(
+      createLlmEvent("evt-2", "2026-03-01T10:05:00.000Z", {
+        skillId: "acme/plan",
+        teamId: "team-1",
+        projectId: "proj-1",
+        inputTokens: 500,
+        outputTokens: 500,
+      }),
+    );
+
+    await usageStorage.store(
+      createLlmEvent("evt-3", "2026-03-02T10:00:00.000Z", {
+        skillId: "acme/review",
+        teamId: "team-2",
+        projectId: "proj-1",
+        inputTokens: 10_000,
+        outputTokens: 10_000,
+      }),
+    );
+
+    const service = new CostAttributionReportService({
+      usageStorage,
+      pricingProvider,
+      now: () => new Date("2026-03-03T00:00:00.000Z"),
+    });
+
+    const report = await service.generateSkillCostReport({
+      startTime: new Date("2026-03-01T00:00:00.000Z"),
+      endTime: new Date("2026-03-02T00:00:00.000Z"),
+      teamId: "team-1",
+      projectId: "proj-1",
+    });
+
+    expect(report.skills.map((skill) => skill.skillId)).toEqual(["acme/review", "acme/plan"]);
+
+    expect(report.skills[0]).toMatchObject({
+      skillId: "acme/review",
+      totalTokens: 2_000,
+    });
+    expect(report.skills[0]?.totalCost).toBeCloseTo(0.003, 8);
+
+    expect(report.skills[1]).toMatchObject({
+      skillId: "acme/plan",
+      totalTokens: 1_000,
+    });
+    expect(report.skills[1]?.totalCost).toBeCloseTo(0.0015, 8);
+  });
+});
+
+function createLlmEvent(
+  id: string,
+  timestamp: string,
+  input: {
+    skillId: string;
+    teamId: string;
+    projectId: string;
+    inputTokens: number;
+    outputTokens: number;
+  },
+): UsageEvent {
+  return {
+    id,
+    timestamp,
+    type: "llm-call",
+    attribution: {
+      developerId: "dev-1",
+      skillId: input.skillId,
+      teamId: input.teamId,
+      projectId: input.projectId,
+    },
+    data: {
+      provider: "openai",
+      model: "gpt-4o-mini",
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      success: true,
+    },
+  };
+}

--- a/packages/core/src/__tests__/cost-schema.test.ts
+++ b/packages/core/src/__tests__/cost-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  aggregateSkillCostAttribution,
   aggregateUsage,
   aggregateUsageByAttribution,
   aggregateUsageByAttributions,
@@ -49,14 +50,24 @@ describe("cost-schema", () => {
       id: "evt-1",
       type: "llm-call",
       timestamp: "2026-01-15T10:00:00Z",
-      attribution: { userId: "user-1", teamId: "team-a", projectId: "project-a" },
+      attribution: {
+        userId: "user-1",
+        teamId: "team-a",
+        projectId: "project-a",
+        skillId: "acme/code-review",
+      },
       data: sampleLlmUsage,
     },
     {
       id: "evt-2",
       type: "llm-call",
       timestamp: "2026-01-15T11:00:00Z",
-      attribution: { userId: "user-2", teamId: "team-a", projectId: "project-a" },
+      attribution: {
+        userId: "user-2",
+        teamId: "team-a",
+        projectId: "project-a",
+        skillId: "acme/security-audit",
+      },
       data: { ...sampleLlmUsage, inputTokens: 2000, outputTokens: 1000 },
     },
     {
@@ -280,6 +291,24 @@ describe("cost-schema", () => {
     });
   });
 
+  describe("aggregateSkillCostAttribution", () => {
+    it("returns per-skill tokens and costs ranked by cost", () => {
+      const report = aggregateSkillCostAttribution(events, pricingMap);
+
+      expect(report[0]).toMatchObject({
+        skillId: "acme/security-audit",
+        totalTokens: 3000,
+      });
+      expect(report[0]?.totalCost).toBeCloseTo(0.021, 6);
+
+      expect(report[1]).toMatchObject({
+        skillId: "acme/code-review",
+        totalTokens: 1500,
+      });
+      expect(report[1]?.totalCost).toBeCloseTo(0.0105, 6);
+    });
+  });
+
   describe("aggregateUsage", () => {
     it("aggregates costs by type", () => {
       const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
@@ -290,6 +319,12 @@ describe("cost-schema", () => {
     it("aggregates costs by provider", () => {
       const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
       expect(summary.byProvider?.["anthropic"]).toBeGreaterThan(0);
+    });
+
+    it("attributes llm costs by skill", () => {
+      const summary = aggregateUsage(events, pricingMap, "2026-01-15", "2026-01-16");
+      expect(summary.bySkill?.["acme/security-audit"]).toBeCloseTo(0.021, 6);
+      expect(summary.bySkill?.["acme/code-review"]).toBeCloseTo(0.0105, 6);
     });
 
     it("aggregates token counts", () => {

--- a/packages/core/src/cost-attribution-report.ts
+++ b/packages/core/src/cost-attribution-report.ts
@@ -1,0 +1,81 @@
+import { aggregateSkillCostAttribution, type SkillCostAttribution } from "./cost-schema.js";
+import type { PricingProvider } from "./pricing-provider.js";
+import type { UsageQueryFilter, UsageStorage } from "./usage-storage.js";
+
+export interface SkillCostAttributionFilter {
+  startTime?: Date;
+  endTime?: Date;
+  teamId?: string;
+  projectId?: string;
+}
+
+export interface SkillCostAttributionReport {
+  generatedAt: string;
+  filter: SkillCostAttributionFilter;
+  skills: SkillCostAttribution[];
+}
+
+export interface CostAttributionReportServiceConfig {
+  usageStorage: UsageStorage;
+  pricingProvider: PricingProvider;
+  now?: () => Date;
+}
+
+export class CostAttributionReportService {
+  private readonly now: () => Date;
+
+  constructor(private readonly config: CostAttributionReportServiceConfig) {
+    this.now = config.now ?? (() => new Date());
+  }
+
+  async generateSkillCostReport(
+    filter: SkillCostAttributionFilter = {},
+  ): Promise<SkillCostAttributionReport> {
+    const endTime = filter.endTime ?? this.now();
+    const queryFilter: UsageQueryFilter = {
+      endTime,
+      ...(filter.startTime ? { startTime: filter.startTime } : {}),
+      ...(filter.teamId ? { teamId: filter.teamId } : {}),
+      ...(filter.projectId ? { projectId: filter.projectId } : {}),
+    };
+
+    const events = await queryAllEvents(this.config.usageStorage, queryFilter);
+    const pricingMap = new Map(
+      (await this.config.pricingProvider.getAllPricing()).map((price) => [
+        `${price.provider}/${price.model}`,
+        price,
+      ]),
+    );
+
+    return {
+      generatedAt: endTime.toISOString(),
+      filter,
+      skills: aggregateSkillCostAttribution(events, pricingMap),
+    };
+  }
+}
+
+export function createCostAttributionReportService(
+  config: CostAttributionReportServiceConfig,
+): CostAttributionReportService {
+  return new CostAttributionReportService(config);
+}
+
+async function queryAllEvents(usageStorage: UsageStorage, filter: UsageQueryFilter) {
+  const pageSize = 500;
+  let offset = 0;
+  const events: Awaited<ReturnType<UsageStorage["query"]>>["data"] = [];
+
+  while (true) {
+    const page = await usageStorage.query(filter, { limit: pageSize, offset });
+    events.push(...page.data);
+
+    if (!page.hasMore) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return events;
+}

--- a/packages/core/src/cost-schema.ts
+++ b/packages/core/src/cost-schema.ts
@@ -174,6 +174,13 @@ export interface AttributionAggregate {
   eventCount: number;
 }
 
+export interface SkillCostAttribution {
+  skillId: string;
+  totalTokens: number;
+  totalCost: number;
+  eventCount: number;
+}
+
 export interface AttributionCombinationAggregate {
   dimensions: Record<AttributionDimension, string>;
   totalCost: number;
@@ -618,6 +625,23 @@ function getEventCost(event: UsageEvent, pricing: Map<string, ModelPricing>): nu
   return calculateLlmCost(data, modelPricing);
 }
 
+function getEventSkillId(event: UsageEvent): string {
+  return (
+    event.attribution.skillId ??
+    (event.type === "skill-invocation" ? (event.data as { skillId: string }).skillId : undefined) ??
+    "unknown"
+  );
+}
+
+function getEventTokenCount(event: UsageEvent): number {
+  if (event.type !== "llm-call") {
+    return 0;
+  }
+
+  const data = event.data as LlmUsage;
+  return data.inputTokens + data.outputTokens;
+}
+
 export function aggregateUsageByAttribution(
   events: UsageEvent[],
   dimension: AttributionDimension,
@@ -692,6 +716,36 @@ export function aggregateUsageBySkill(
   return aggregateUsageByAttribution(events, "skillId", pricing);
 }
 
+export function aggregateSkillCostAttribution(
+  events: UsageEvent[],
+  pricing: Map<string, ModelPricing>,
+): SkillCostAttribution[] {
+  const grouped = new Map<string, SkillCostAttribution>();
+
+  for (const event of events) {
+    const skillId = getEventSkillId(event);
+    const existing = grouped.get(skillId) ?? {
+      skillId,
+      totalTokens: 0,
+      totalCost: 0,
+      eventCount: 0,
+    };
+
+    existing.totalTokens += getEventTokenCount(event);
+    existing.totalCost += getEventCost(event, pricing);
+    existing.eventCount += 1;
+
+    grouped.set(skillId, existing);
+  }
+
+  return Array.from(grouped.values()).sort(
+    (a, b) =>
+      b.totalCost - a.totalCost ||
+      b.totalTokens - a.totalTokens ||
+      a.skillId.localeCompare(b.skillId),
+  );
+}
+
 export function aggregateUsage(
   events: UsageEvent[],
   pricing: Map<string, ModelPricing>,
@@ -724,10 +778,8 @@ export function aggregateUsage(
       outputTokens += data.outputTokens;
     }
 
-    if (event.type === "skill-invocation") {
-      const data = event.data as { skillId: string };
-      bySkill[data.skillId] = (bySkill[data.skillId] ?? 0) + eventCost;
-    }
+    const skillId = getEventSkillId(event);
+    bySkill[skillId] = (bySkill[skillId] ?? 0) + eventCost;
 
     byType[event.type] = (byType[event.type] ?? 0) + eventCost;
     totalCost += eventCost;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,15 @@ export {
   createCostAnomalyDetector,
 } from "./cost-anomaly.js";
 export type {
+  CostAttributionReportServiceConfig,
+  SkillCostAttributionFilter,
+  SkillCostAttributionReport,
+} from "./cost-attribution-report.js";
+export {
+  CostAttributionReportService,
+  createCostAttributionReportService,
+} from "./cost-attribution-report.js";
+export type {
   FallbackPricing,
   LlmCostBreakdown,
   MissingPriceStrategy,
@@ -129,12 +138,14 @@ export type {
   McpInvocationUsage,
   MemoryOperationUsage,
   ModelPricing,
+  SkillCostAttribution,
   SkillInvocationUsage,
   UsageAttribution,
   UsageEvent,
   UsageEventType,
 } from "./cost-schema.js";
 export {
+  aggregateSkillCostAttribution,
   aggregateUsage,
   aggregateUsageByAttribution,
   aggregateUsageByAttributions,


### PR DESCRIPTION
## Summary
- add a new `CostAttributionReportService` API to generate per-skill attribution reports with token totals and estimated costs
- support filtering the report by date range, team, and project
- rank skills by estimated cost (descending) by default
- fix `aggregateUsage` skill breakdown to attribute LLM costs by `attribution.skillId`
- add focused tests for report generation/filtering and per-skill aggregation behavior

## Validation
- `pnpm --filter @laup/core typecheck`
- `pnpm test:run packages/core/src/__tests__/cost-schema.test.ts packages/core/src/__tests__/cost-attribution-report.test.ts packages/core/src/__tests__/cost-dashboard.test.ts`

Closes #104
