### PR TITLE
feat(core): support model routing recommendations in cost dashboard

### DIFF
--- a/packages/core/src/__tests__/cost-dashboard.test.ts
+++ b/packages/core/src/__tests__/cost-dashboard.test.ts
@@ -67,6 +67,73 @@ describe("CostDashboardService", () => {
     expect(snapshot.historical.points[1]?.summary.totalCost).toBeCloseTo(0.009, 8);
   });
 
+  it("surfaces model routing recommendations and automatic rules", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const pricingProvider = new InMemoryPricingProvider({
+      initialPricing: [
+        {
+          provider: "openai",
+          model: "gpt-4o",
+          inputCostPerMillion: 10,
+          outputCostPerMillion: 30,
+          effectiveDate: "2026-01-01",
+          currency: "USD",
+        },
+        {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          inputCostPerMillion: 1,
+          outputCostPerMillion: 2,
+          effectiveDate: "2026-01-01",
+          currency: "USD",
+        },
+      ],
+    });
+
+    for (let index = 0; index < 6; index += 1) {
+      await store(usageStorage, `2026-03-03T17:${40 + index}:00.000Z`, {
+        provider: "openai",
+        model: "gpt-4o",
+        inputTokens: 1000,
+        outputTokens: 500,
+        toolCategory: "analysis",
+      });
+    }
+
+    const service = new CostDashboardService({
+      usageStorage,
+      pricingProvider,
+      windows: [{ id: "30m", durationMs: 30 * 60_000 }],
+      routingRecommendations: {
+        enabled: true,
+        minEvents: 5,
+        autoRouting: {
+          enabled: true,
+          minimumConfidence: 0.5,
+          minimumSavingsUsd: 0.01,
+        },
+      },
+      now: () => new Date(),
+    });
+
+    const snapshot = await service.snapshot();
+
+    expect(snapshot.routingRecommendations.recommendations).toHaveLength(1);
+    expect(snapshot.routingRecommendations.recommendations[0]).toMatchObject({
+      taskType: "analysis",
+      currentModel: "gpt-4o",
+      suggestedModel: "gpt-4o-mini",
+    });
+    expect(snapshot.routingRecommendations.autoRouting.rules).toHaveLength(1);
+    expect(snapshot.routingRecommendations.autoRouting.rules[0]).toMatchObject({
+      fromModel: "gpt-4o",
+      toModel: "gpt-4o-mini",
+      taskType: "analysis",
+    });
+  });
+
   it("keeps token and event counts when pricing is unavailable", async () => {
     const usageStorage = new InMemoryUsageStorage();
     await usageStorage.init();
@@ -105,6 +172,7 @@ async function store(
     model?: string;
     inputTokens: number;
     outputTokens: number;
+    toolCategory?: string;
   },
 ): Promise<void> {
   const event: UsageEvent = {
@@ -117,6 +185,7 @@ async function store(
       projectId: "proj-1",
       sessionId: "session-1",
       adapterId: "adapter-1",
+      toolCategory: data.toolCategory,
     },
     data: {
       provider: data.provider ?? "openai",

--- a/packages/core/src/__tests__/cost-routing-recommendations.test.ts
+++ b/packages/core/src/__tests__/cost-routing-recommendations.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAutoModelRoutingRules,
+  generateModelRoutingRecommendations,
+} from "../cost-routing-recommendations.js";
+import type { ModelPricing, UsageEvent } from "../cost-schema.js";
+
+describe("cost-routing-recommendations (COST-010)", () => {
+  it("generates recommendations by task type with estimated savings and confidence", () => {
+    const pricing = createPricing([
+      {
+        provider: "openai",
+        model: "gpt-4o",
+        inputCostPerMillion: 10,
+        outputCostPerMillion: 30,
+      },
+      {
+        provider: "openai",
+        model: "gpt-4o-mini",
+        inputCostPerMillion: 1,
+        outputCostPerMillion: 2,
+      },
+    ]);
+
+    const events = Array.from({ length: 6 }, (_, index) =>
+      createLlmEvent(`evt-${index}`, "openai", "gpt-4o", "code", 10_000, 5_000),
+    );
+
+    const recommendations = generateModelRoutingRecommendations(events, pricing, { minEvents: 5 });
+
+    expect(recommendations).toHaveLength(1);
+    expect(recommendations[0]).toMatchObject({
+      taskType: "code",
+      provider: "openai",
+      currentModel: "gpt-4o",
+      suggestedModel: "gpt-4o-mini",
+      eventCount: 6,
+    });
+    expect(recommendations[0]?.estimatedSavings).toBeGreaterThan(0);
+    expect(recommendations[0]?.confidence).toBeGreaterThan(0);
+  });
+
+  it("builds automatic routing rules from recommendation thresholds", () => {
+    const rules = buildAutoModelRoutingRules(
+      [
+        {
+          taskType: "analysis",
+          provider: "openai",
+          currentModel: "gpt-4o",
+          suggestedModel: "gpt-4o-mini",
+          currentCost: 1,
+          suggestedCost: 0.2,
+          estimatedSavings: 0.8,
+          confidence: 0.9,
+          eventCount: 10,
+        },
+      ],
+      {
+        enabled: true,
+        minimumConfidence: 0.85,
+        minimumSavingsUsd: 0.5,
+      },
+    );
+
+    expect(rules).toEqual([
+      {
+        taskType: "analysis",
+        provider: "openai",
+        fromModel: "gpt-4o",
+        toModel: "gpt-4o-mini",
+        confidence: 0.9,
+        estimatedSavings: 0.8,
+      },
+    ]);
+  });
+});
+
+function createPricing(
+  models: Array<{
+    provider: string;
+    model: string;
+    inputCostPerMillion: number;
+    outputCostPerMillion: number;
+  }>,
+): Map<string, ModelPricing> {
+  return new Map(
+    models.map((model) => [
+      `${model.provider}/${model.model}`,
+      {
+        ...model,
+        effectiveDate: "2026-01-01",
+        currency: "USD",
+      },
+    ]),
+  );
+}
+
+function createLlmEvent(
+  id: string,
+  provider: string,
+  model: string,
+  taskType: string,
+  inputTokens: number,
+  outputTokens: number,
+): UsageEvent {
+  return {
+    id,
+    type: "llm-call",
+    timestamp: "2026-03-03T18:00:00.000Z",
+    attribution: {
+      toolCategory: taskType,
+      sessionId: "session-1",
+    },
+    data: {
+      provider,
+      model,
+      inputTokens,
+      outputTokens,
+      success: true,
+    },
+  };
+}

--- a/packages/core/src/cost-dashboard.ts
+++ b/packages/core/src/cost-dashboard.ts
@@ -1,4 +1,11 @@
 import { z } from "zod";
+import {
+  type AutoModelRoutingPolicy,
+  AutoModelRoutingPolicySchema,
+  buildAutoModelRoutingRules,
+  generateModelRoutingRecommendations,
+  type ModelRoutingRecommendation,
+} from "./cost-routing-recommendations.js";
 import { aggregateUsage, type CostSummary } from "./cost-schema.js";
 import type { PricingProvider } from "./pricing-provider.js";
 import type { UsageStorage } from "./usage-storage.js";
@@ -17,11 +24,27 @@ export const CostDashboardHistoricalConfigSchema = z.object({
 
 export type CostDashboardHistoricalConfig = z.infer<typeof CostDashboardHistoricalConfigSchema>;
 
+export const CostDashboardRoutingRecommendationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  minEvents: z.number().int().positive().default(5),
+  maxRecommendations: z.number().int().positive().default(20),
+  autoRouting: AutoModelRoutingPolicySchema.default({
+    enabled: false,
+    minimumConfidence: 0.75,
+    minimumSavingsUsd: 0,
+  }),
+});
+
+export type CostDashboardRoutingRecommendationConfig = z.infer<
+  typeof CostDashboardRoutingRecommendationConfigSchema
+>;
+
 export interface CostDashboardConfig {
   usageStorage: UsageStorage;
   pricingProvider: PricingProvider;
   windows?: CostDashboardWindow[];
   historical?: Partial<CostDashboardHistoricalConfig>;
+  routingRecommendations?: Partial<CostDashboardRoutingRecommendationConfig>;
   now?: () => Date;
 }
 
@@ -50,6 +73,22 @@ export interface CostDashboardSnapshot {
     bucket: "hour" | "day";
     points: CostDashboardHistoryPoint[];
   };
+  routingRecommendations: {
+    enabled: boolean;
+    recommendations: ModelRoutingRecommendation[];
+    autoRouting: {
+      enabled: boolean;
+      policy: AutoModelRoutingPolicy;
+      rules: Array<{
+        taskType: string;
+        provider: string;
+        fromModel: string;
+        toModel: string;
+        confidence: number;
+        estimatedSavings: number;
+      }>;
+    };
+  };
 }
 
 const DEFAULT_WINDOWS: CostDashboardWindow[] = [
@@ -62,11 +101,15 @@ export class CostDashboardService {
   private readonly now: () => Date;
   private readonly windows: CostDashboardWindow[];
   private readonly historical: CostDashboardHistoricalConfig;
+  private readonly routingRecommendations: CostDashboardRoutingRecommendationConfig;
 
   constructor(private readonly config: CostDashboardConfig) {
     this.now = config.now ?? (() => new Date());
     this.windows = normalizeWindows(config.windows ?? DEFAULT_WINDOWS);
     this.historical = CostDashboardHistoricalConfigSchema.parse(config.historical ?? {});
+    this.routingRecommendations = CostDashboardRoutingRecommendationConfigSchema.parse(
+      config.routingRecommendations ?? {},
+    );
   }
 
   async snapshot(): Promise<CostDashboardSnapshot> {
@@ -104,6 +147,18 @@ export class CostDashboardService {
 
     const historicalPoints = buildHistory(events, pricingMap, endTime, this.historical);
 
+    const recommendations = this.routingRecommendations.enabled
+      ? generateModelRoutingRecommendations(events, pricingMap, {
+          minEvents: this.routingRecommendations.minEvents,
+          maxRecommendations: this.routingRecommendations.maxRecommendations,
+        })
+      : [];
+
+    const autoRoutingRules = buildAutoModelRoutingRules(
+      recommendations,
+      this.routingRecommendations.autoRouting,
+    );
+
     return {
       generatedAt: endTime.toISOString(),
       realtime: {
@@ -116,6 +171,15 @@ export class CostDashboardService {
       historical: {
         bucket: this.historical.bucket,
         points: historicalPoints,
+      },
+      routingRecommendations: {
+        enabled: this.routingRecommendations.enabled,
+        recommendations,
+        autoRouting: {
+          enabled: this.routingRecommendations.autoRouting.enabled,
+          policy: this.routingRecommendations.autoRouting,
+          rules: autoRoutingRules,
+        },
       },
     };
   }

--- a/packages/core/src/cost-routing-recommendations.ts
+++ b/packages/core/src/cost-routing-recommendations.ts
@@ -1,0 +1,194 @@
+import { z } from "zod";
+import {
+  calculateLlmCost,
+  type LlmUsage,
+  type ModelPricing,
+  type UsageEvent,
+} from "./cost-schema.js";
+
+export const ModelRoutingRecommendationSchema = z.object({
+  taskType: z.string(),
+  provider: z.string(),
+  currentModel: z.string(),
+  suggestedModel: z.string(),
+  currentCost: z.number().nonnegative(),
+  suggestedCost: z.number().nonnegative(),
+  estimatedSavings: z.number().nonnegative(),
+  confidence: z.number().min(0).max(1),
+  eventCount: z.number().int().positive(),
+});
+
+export type ModelRoutingRecommendation = z.infer<typeof ModelRoutingRecommendationSchema>;
+
+export const AutoModelRoutingPolicySchema = z.object({
+  enabled: z.boolean().default(false),
+  minimumConfidence: z.number().min(0).max(1).default(0.75),
+  minimumSavingsUsd: z.number().nonnegative().default(0),
+});
+
+export type AutoModelRoutingPolicy = z.infer<typeof AutoModelRoutingPolicySchema>;
+
+export interface AutoModelRoutingRule {
+  taskType: string;
+  provider: string;
+  fromModel: string;
+  toModel: string;
+  confidence: number;
+  estimatedSavings: number;
+}
+
+export interface ModelRoutingRecommendationOptions {
+  minEvents?: number;
+  maxRecommendations?: number;
+}
+
+interface ModelUsagePattern {
+  provider: string;
+  model: string;
+  taskType: string;
+  eventCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  successCount: number;
+}
+
+export function generateModelRoutingRecommendations(
+  events: UsageEvent[],
+  pricing: Map<string, ModelPricing>,
+  options: ModelRoutingRecommendationOptions = {},
+): ModelRoutingRecommendation[] {
+  const minEvents = options.minEvents ?? 5;
+  const maxRecommendations = options.maxRecommendations ?? 20;
+
+  const patterns = aggregatePatterns(events);
+  const recommendations: ModelRoutingRecommendation[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.eventCount < minEvents) {
+      continue;
+    }
+
+    const currentPricing = pricing.get(`${pattern.provider}/${pattern.model}`);
+    if (!currentPricing) {
+      continue;
+    }
+
+    const currentCost = estimateCost(pattern, currentPricing);
+
+    let bestAlternative: { model: string; cost: number } | null = null;
+    for (const candidate of pricing.values()) {
+      if (candidate.provider !== pattern.provider || candidate.model === pattern.model) {
+        continue;
+      }
+
+      const candidateCost = estimateCost(pattern, candidate);
+      if (candidateCost >= currentCost) {
+        continue;
+      }
+
+      if (!bestAlternative || candidateCost < bestAlternative.cost) {
+        bestAlternative = { model: candidate.model, cost: candidateCost };
+      }
+    }
+
+    if (!bestAlternative) {
+      continue;
+    }
+
+    const estimatedSavings = currentCost - bestAlternative.cost;
+    const confidence = computeConfidence(pattern);
+
+    recommendations.push({
+      taskType: pattern.taskType,
+      provider: pattern.provider,
+      currentModel: pattern.model,
+      suggestedModel: bestAlternative.model,
+      currentCost,
+      suggestedCost: bestAlternative.cost,
+      estimatedSavings,
+      confidence,
+      eventCount: pattern.eventCount,
+    });
+  }
+
+  return recommendations
+    .sort((a, b) => b.estimatedSavings - a.estimatedSavings || b.confidence - a.confidence)
+    .slice(0, maxRecommendations);
+}
+
+export function buildAutoModelRoutingRules(
+  recommendations: ModelRoutingRecommendation[],
+  policy: AutoModelRoutingPolicy,
+): AutoModelRoutingRule[] {
+  if (!policy.enabled) {
+    return [];
+  }
+
+  return recommendations
+    .filter(
+      (recommendation) =>
+        recommendation.confidence >= policy.minimumConfidence &&
+        recommendation.estimatedSavings >= policy.minimumSavingsUsd,
+    )
+    .map((recommendation) => ({
+      taskType: recommendation.taskType,
+      provider: recommendation.provider,
+      fromModel: recommendation.currentModel,
+      toModel: recommendation.suggestedModel,
+      confidence: recommendation.confidence,
+      estimatedSavings: recommendation.estimatedSavings,
+    }));
+}
+
+function aggregatePatterns(events: UsageEvent[]): ModelUsagePattern[] {
+  const groups = new Map<string, ModelUsagePattern>();
+
+  for (const event of events) {
+    if (event.type !== "llm-call") {
+      continue;
+    }
+
+    const usage = event.data as LlmUsage;
+    const taskType = event.attribution.toolCategory ?? event.attribution.skillId ?? "general";
+    const key = `${usage.provider}/${usage.model}/${taskType}`;
+
+    const existing = groups.get(key) ?? {
+      provider: usage.provider,
+      model: usage.model,
+      taskType,
+      eventCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      successCount: 0,
+    };
+
+    existing.eventCount += 1;
+    existing.inputTokens += usage.inputTokens;
+    existing.outputTokens += usage.outputTokens;
+    existing.successCount += usage.success ? 1 : 0;
+
+    groups.set(key, existing);
+  }
+
+  return Array.from(groups.values());
+}
+
+function estimateCost(pattern: ModelUsagePattern, pricing: ModelPricing): number {
+  return calculateLlmCost(
+    {
+      provider: pattern.provider,
+      model: pricing.model,
+      inputTokens: pattern.inputTokens,
+      outputTokens: pattern.outputTokens,
+      success: true,
+    },
+    pricing,
+  );
+}
+
+function computeConfidence(pattern: ModelUsagePattern): number {
+  const sampleConfidence = Math.min(pattern.eventCount / 20, 1) * 0.6;
+  const successRate = pattern.successCount / pattern.eventCount;
+  const successConfidence = successRate * 0.4;
+  return Number(Math.min(sampleConfidence + successConfidence, 1).toFixed(4));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -106,15 +106,29 @@ export {
 export type {
   CostDashboardHistoricalConfig,
   CostDashboardHistoryPoint,
+  CostDashboardRoutingRecommendationConfig,
   CostDashboardSnapshot,
   CostDashboardWindow,
 } from "./cost-dashboard.js";
 export {
   CostDashboardHistoricalConfigSchema,
+  CostDashboardRoutingRecommendationConfigSchema,
   CostDashboardService,
   CostDashboardWindowSchema,
   createCostDashboardService,
 } from "./cost-dashboard.js";
+export type {
+  AutoModelRoutingPolicy,
+  AutoModelRoutingRule,
+  ModelRoutingRecommendation,
+  ModelRoutingRecommendationOptions,
+} from "./cost-routing-recommendations.js";
+export {
+  AutoModelRoutingPolicySchema,
+  buildAutoModelRoutingRules,
+  generateModelRoutingRecommendations,
+  ModelRoutingRecommendationSchema,
+} from "./cost-routing-recommendations.js";
 export type {
   AttributionAggregate,
   AttributionCombinationAggregate,


### PR DESCRIPTION
## Summary
- add COST-010 model routing recommendation analysis from LLM usage patterns grouped by task type
- include recommendation payload fields (current/suggested model, estimated savings, confidence)
- surface recommendations in `CostDashboardSnapshot` and support configurable automatic routing rules
- export new recommendation APIs from `@laup/core` and cover behavior with tests

## Validation
- `pnpm --filter @laup/core typecheck`
- `pnpm test:run packages/core/src/__tests__/cost-dashboard.test.ts packages/core/src/__tests__/cost-routing-recommendations.test.ts`

Closes #105
