### PR TITLE
feat(core): support chargeback reporting by cost center

### DIFF
--- a/packages/core/src/__tests__/chargeback-report.test.ts
+++ b/packages/core/src/__tests__/chargeback-report.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ChargebackMappingRule,
+  ChargebackReportService,
+  exportChargebackReport,
+} from "../chargeback-report.js";
+import type { UsageEvent } from "../cost-schema.js";
+import { InMemoryPricingProvider } from "../pricing-provider.js";
+import { InMemoryUsageStorage } from "../usage-storage.js";
+
+describe("ChargebackReportService", () => {
+  it("allocates costs to configurable cost centers with team/project/custom mappings", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const pricingProvider = new InMemoryPricingProvider({
+      initialPricing: [
+        {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          inputCostPerMillion: 1,
+          outputCostPerMillion: 2,
+          effectiveDate: "2026-01-01",
+          currency: "USD",
+        },
+      ],
+    });
+
+    await usageStorage.store(
+      createLlmEvent("evt-1", "2026-03-05T10:00:00.000Z", {
+        teamId: "team-eng",
+        projectId: "proj-platform",
+        inputTokens: 1_000,
+        outputTokens: 1_000,
+      }),
+    );
+
+    await usageStorage.store(
+      createLlmEvent("evt-2", "2026-03-06T10:00:00.000Z", {
+        teamId: "team-fin",
+        projectId: "proj-finance",
+        inputTokens: 2_000,
+        outputTokens: 1_000,
+      }),
+    );
+
+    await usageStorage.store(
+      createLlmEvent("evt-3", "2026-03-07T10:00:00.000Z", {
+        teamId: "team-mkt",
+        projectId: "proj-marketing",
+        orgId: "marketing",
+        inputTokens: 500,
+        outputTokens: 500,
+      }),
+    );
+
+    const mappings: ChargebackMappingRule[] = [
+      {
+        costCenter: "CC-ENG",
+        groupType: "team",
+        groupId: "team-eng",
+        groupName: "Engineering",
+        match: { teamId: "team-eng" },
+      },
+      {
+        costCenter: "CC-FIN",
+        groupType: "project",
+        groupId: "proj-finance",
+        groupName: "Finance Platform",
+        match: { projectId: "proj-finance" },
+      },
+      {
+        costCenter: "CC-MKT-CAMPAIGN",
+        groupType: "custom",
+        groupId: "brand-awareness",
+        groupName: "Brand Awareness",
+        match: { orgId: "marketing" },
+      },
+    ];
+
+    const service = new ChargebackReportService({
+      usageStorage,
+      pricingProvider,
+      now: () => new Date("2026-03-10T00:00:00.000Z"),
+    });
+
+    const report = await service.generate({ mappings });
+
+    expect(report.billingPeriod).toEqual({
+      startTime: "2026-03-01T00:00:00.000Z",
+      endTime: "2026-04-01T00:00:00.000Z",
+      granularity: "month",
+    });
+
+    expect(report.rows).toHaveLength(3);
+    expect(report.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          costCenter: "CC-ENG",
+          groupType: "team",
+          groupId: "team-eng",
+          totalCost: expect.closeTo(0.003, 8),
+        }),
+        expect.objectContaining({
+          costCenter: "CC-FIN",
+          groupType: "project",
+          groupId: "proj-finance",
+          totalCost: expect.closeTo(0.004, 8),
+        }),
+        expect.objectContaining({
+          costCenter: "CC-MKT-CAMPAIGN",
+          groupType: "custom",
+          groupId: "brand-awareness",
+          totalCost: expect.closeTo(0.0015, 8),
+        }),
+      ]),
+    );
+  });
+
+  it("exports chargeback report to CSV and JSON", async () => {
+    const usageStorage = new InMemoryUsageStorage();
+    await usageStorage.init();
+
+    const pricingProvider = new InMemoryPricingProvider({
+      initialPricing: [
+        {
+          provider: "openai",
+          model: "gpt-4o-mini",
+          inputCostPerMillion: 1,
+          outputCostPerMillion: 2,
+          effectiveDate: "2026-01-01",
+          currency: "USD",
+        },
+      ],
+    });
+
+    await usageStorage.store(
+      createLlmEvent("evt-4", "2026-02-01T12:00:00.000Z", {
+        teamId: "team-fin",
+        projectId: "proj-finance",
+        costCenter: "CC-FIN",
+        inputTokens: 1_000,
+        outputTokens: 1_000,
+      }),
+    );
+
+    const service = new ChargebackReportService({
+      usageStorage,
+      pricingProvider,
+      now: () => new Date("2026-02-20T00:00:00.000Z"),
+    });
+
+    const report = await service.generate({
+      billingPeriod: {
+        startTime: new Date("2026-02-01T00:00:00.000Z"),
+        endTime: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    });
+
+    const json = exportChargebackReport(report, { format: "json" });
+    const csv = exportChargebackReport(report, { format: "csv" });
+
+    expect(() => JSON.parse(json)).not.toThrow();
+    expect(csv).toContain("periodStart,periodEnd,costCenter,groupType,groupId");
+    expect(csv).toContain("CC-FIN,costCenter,CC-FIN");
+  });
+});
+
+function createLlmEvent(
+  id: string,
+  timestamp: string,
+  input: {
+    teamId: string;
+    projectId: string;
+    orgId?: string;
+    costCenter?: string;
+    inputTokens: number;
+    outputTokens: number;
+  },
+): UsageEvent {
+  return {
+    id,
+    timestamp,
+    type: "llm-call",
+    attribution: {
+      developerId: "dev-1",
+      teamId: input.teamId,
+      projectId: input.projectId,
+      orgId: input.orgId,
+      costCenter: input.costCenter,
+    },
+    data: {
+      provider: "openai",
+      model: "gpt-4o-mini",
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      success: true,
+    },
+  };
+}

--- a/packages/core/src/chargeback-report.ts
+++ b/packages/core/src/chargeback-report.ts
@@ -1,0 +1,261 @@
+import {
+  calculateLlmCost,
+  type LlmUsage,
+  type ModelPricing,
+  type UsageAttribution,
+  type UsageEvent,
+} from "./cost-schema.js";
+import type { PricingProvider } from "./pricing-provider.js";
+import type { UsageQueryFilter, UsageStorage } from "./usage-storage.js";
+
+export type ChargebackGroupType = "team" | "project" | "custom";
+
+export interface ChargebackMappingRule {
+  costCenter: string;
+  groupType: ChargebackGroupType;
+  groupId: string;
+  groupName?: string;
+  match: Partial<UsageAttribution>;
+}
+
+export interface ChargebackBillingPeriod {
+  startTime: Date;
+  endTime: Date;
+}
+
+export interface ChargebackReportRow {
+  costCenter: string;
+  groupType: ChargebackGroupType | "costCenter";
+  groupId: string;
+  groupName?: string;
+  totalCost: number;
+  totalTokens: number;
+  eventCount: number;
+}
+
+export interface ChargebackReport {
+  generatedAt: string;
+  billingPeriod: {
+    startTime: string;
+    endTime: string;
+    granularity: "month" | "custom";
+  };
+  rows: ChargebackReportRow[];
+}
+
+export interface ChargebackReportServiceConfig {
+  usageStorage: UsageStorage;
+  pricingProvider: PricingProvider;
+  now?: () => Date;
+}
+
+export interface GenerateChargebackReportInput {
+  billingPeriod?: ChargebackBillingPeriod;
+  mappings?: ChargebackMappingRule[];
+}
+
+export interface ChargebackExportOptions {
+  format: "json" | "csv";
+  pretty?: boolean;
+  includeHeaders?: boolean;
+}
+
+export class ChargebackReportService {
+  private readonly now: () => Date;
+
+  constructor(private readonly config: ChargebackReportServiceConfig) {
+    this.now = config.now ?? (() => new Date());
+  }
+
+  async generate(input: GenerateChargebackReportInput = {}): Promise<ChargebackReport> {
+    const resolvedPeriod = resolveBillingPeriod(input.billingPeriod, this.now());
+
+    const events = await queryAllEvents(this.config.usageStorage, {
+      startTime: resolvedPeriod.startTime,
+      endTime: resolvedPeriod.endTime,
+    });
+    const pricingMap = new Map(
+      (await this.config.pricingProvider.getAllPricing()).map((price) => [
+        `${price.provider}/${price.model}`,
+        price,
+      ]),
+    );
+
+    const rows = aggregateChargebackRows(events, pricingMap, input.mappings ?? []);
+
+    return {
+      generatedAt: this.now().toISOString(),
+      billingPeriod: {
+        startTime: resolvedPeriod.startTime.toISOString(),
+        endTime: resolvedPeriod.endTime.toISOString(),
+        granularity: input.billingPeriod ? "custom" : "month",
+      },
+      rows,
+    };
+  }
+}
+
+export function createChargebackReportService(
+  config: ChargebackReportServiceConfig,
+): ChargebackReportService {
+  return new ChargebackReportService(config);
+}
+
+export function exportChargebackReport(
+  report: ChargebackReport,
+  options: ChargebackExportOptions,
+): string {
+  if (options.format === "json") {
+    return options.pretty ? JSON.stringify(report, null, 2) : JSON.stringify(report);
+  }
+
+  const headers = [
+    "periodStart",
+    "periodEnd",
+    "costCenter",
+    "groupType",
+    "groupId",
+    "groupName",
+    "totalCost",
+    "totalTokens",
+    "eventCount",
+  ];
+  const lines: string[] = [];
+
+  if (options.includeHeaders !== false) {
+    lines.push(headers.join(","));
+  }
+
+  for (const row of report.rows) {
+    const values = [
+      report.billingPeriod.startTime,
+      report.billingPeriod.endTime,
+      row.costCenter,
+      row.groupType,
+      row.groupId,
+      row.groupName ?? "",
+      row.totalCost,
+      row.totalTokens,
+      row.eventCount,
+    ].map(escapeCsvValue);
+    lines.push(values.join(","));
+  }
+
+  return lines.join("\n");
+}
+
+function resolveBillingPeriod(
+  billingPeriod: ChargebackBillingPeriod | undefined,
+  reference: Date,
+): ChargebackBillingPeriod {
+  if (billingPeriod) {
+    return billingPeriod;
+  }
+
+  const startTime = new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), 1));
+  const endTime = new Date(Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth() + 1, 1));
+  return { startTime, endTime };
+}
+
+function escapeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function getLlmCost(
+  event: UsageEvent,
+  pricingMap: Map<string, ModelPricing>,
+): { cost: number; tokens: number } {
+  if (event.type !== "llm-call") {
+    return { cost: 0, tokens: 0 };
+  }
+
+  const data = event.data as LlmUsage;
+  const modelPricing = pricingMap.get(`${data.provider}/${data.model}`);
+  if (!modelPricing) {
+    return {
+      cost: 0,
+      tokens: data.inputTokens + data.outputTokens,
+    };
+  }
+
+  return {
+    cost: calculateLlmCost(data, modelPricing),
+    tokens: data.inputTokens + data.outputTokens,
+  };
+}
+
+function aggregateChargebackRows(
+  events: UsageEvent[],
+  pricingMap: Map<string, ModelPricing>,
+  mappings: ChargebackMappingRule[],
+): ChargebackReportRow[] {
+  const grouped = new Map<string, ChargebackReportRow>();
+
+  for (const event of events) {
+    const { cost, tokens } = getLlmCost(event, pricingMap);
+    const mapping = mappings.find((rule) => matchesAttribution(event.attribution, rule.match));
+
+    const costCenter = mapping?.costCenter ?? event.attribution.costCenter ?? "unmapped";
+    const groupType = mapping?.groupType ?? "costCenter";
+    const groupId = mapping?.groupId ?? costCenter;
+    const groupName = mapping?.groupName;
+
+    const key = `${costCenter}::${groupType}::${groupId}`;
+    const existing =
+      grouped.get(key) ??
+      ({
+        costCenter,
+        groupType,
+        groupId,
+        ...(groupName ? { groupName } : {}),
+        totalCost: 0,
+        totalTokens: 0,
+        eventCount: 0,
+      } satisfies ChargebackReportRow);
+
+    existing.totalCost += cost;
+    existing.totalTokens += tokens;
+    existing.eventCount += 1;
+
+    grouped.set(key, existing);
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => b.totalCost - a.totalCost);
+}
+
+function matchesAttribution(
+  attribution: UsageAttribution,
+  matcher: Partial<UsageAttribution>,
+): boolean {
+  return Object.entries(matcher).every(([key, value]) => {
+    if (value === undefined) {
+      return true;
+    }
+
+    return attribution[key as keyof UsageAttribution] === value;
+  });
+}
+
+async function queryAllEvents(usageStorage: UsageStorage, filter: UsageQueryFilter) {
+  const pageSize = 500;
+  let offset = 0;
+  const events: Awaited<ReturnType<UsageStorage["query"]>>["data"] = [];
+
+  while (true) {
+    const page = await usageStorage.query(filter, { limit: pageSize, offset });
+    events.push(...page.data);
+
+    if (!page.hasMore) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return events;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,21 @@ export {
   TieredCache,
 } from "./cache.js";
 export type {
+  ChargebackBillingPeriod,
+  ChargebackExportOptions,
+  ChargebackGroupType,
+  ChargebackMappingRule,
+  ChargebackReport,
+  ChargebackReportRow,
+  ChargebackReportServiceConfig,
+  GenerateChargebackReportInput,
+} from "./chargeback-report.js";
+export {
+  ChargebackReportService,
+  createChargebackReportService,
+  exportChargebackReport,
+} from "./chargeback-report.js";
+export type {
   ClaudeCodeDeserializerOutput,
   ClaudeCodeSerializerInput,
   ClaudeCodeTaskContext,


### PR DESCRIPTION
## Summary
- add `ChargebackReportService` to generate cost allocation reports by configurable cost center mappings
- support mapping cost centers to teams, projects, or custom groupings via rule-based attribution matching
- add export support for JSON and CSV for finance/ERP workflows
- default report window to current monthly billing period, with configurable custom billing periods
- export new APIs from `@laup/core` index
- add focused unit tests for allocation logic and export formats

## Validation
- `pnpm typecheck` ✅
- `pnpm test:run` ✅
- `pnpm lint` ⚠️ fails due to pre-existing repository-wide Biome violations unrelated to this PR

Closes #106
