### PR TITLE
feat(core): support marketplace author skill analytics

### DIFF
--- a/packages/core/src/__tests__/marketplace.test.ts
+++ b/packages/core/src/__tests__/marketplace.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   createMarketplaceApiHandler,
+  InMemoryMarketplaceSkillAnalytics,
   InMemorySkillMarketplace,
   type MarketplaceSkill,
+  renderMarketplaceAuthorAnalyticsPage,
   renderMarketplacePage,
 } from "../marketplace.js";
 
@@ -83,6 +85,81 @@ describe("marketplace", () => {
     });
   });
 
+  describe("author analytics", () => {
+    it("aggregates installs, invocation frequency, and parameter usage", async () => {
+      const marketplace = makeMarketplace();
+      const analytics = new InMemoryMarketplaceSkillAnalytics(
+        marketplace,
+        () => new Date("2026-03-01T12:00:00.000Z"),
+      );
+
+      await analytics.recordInstall({
+        skillId: "acme/weather",
+        version: "1.0.0",
+        timestamp: "2026-02-01T01:00:00.000Z",
+      });
+      await analytics.recordInstall({
+        skillId: "acme/weather",
+        version: "1.2.0",
+        timestamp: "2026-02-02T01:00:00.000Z",
+      });
+      await analytics.recordInstall({
+        skillId: "acme/calendar",
+        version: "2.1.0",
+        timestamp: "2026-02-02T05:00:00.000Z",
+      });
+      await analytics.recordInstall({
+        skillId: "labs/release-notes",
+        version: "0.9.1",
+        timestamp: "2026-02-03T05:00:00.000Z",
+      });
+
+      await analytics.recordInvocation({
+        skillId: "acme/weather",
+        invocationCount: 3,
+        parameters: { location: "Austin", units: "metric" },
+        defaultParameters: ["units"],
+        timestamp: "2026-02-02T01:00:00.000Z",
+      });
+      await analytics.recordInvocation({
+        skillId: "acme/calendar",
+        invocationCount: 2,
+        parameters: { timezone: "America/Chicago" },
+        timestamp: "2026-02-10T01:00:00.000Z",
+      });
+      await analytics.recordInvocation({
+        skillId: "labs/release-notes",
+        invocationCount: 10,
+        parameters: { format: "markdown" },
+        timestamp: "2026-02-10T01:00:00.000Z",
+      });
+
+      const report = await analytics.getAuthorAnalytics("acme", { interval: "weekly" });
+
+      expect(report.installs.byVersion).toEqual([
+        { version: "1.0.0", count: 1 },
+        { version: "1.2.0", count: 1 },
+        { version: "2.1.0", count: 1 },
+      ]);
+      expect(report.installs.overTime).toEqual([
+        { periodStart: "2026-01-26T00:00:00.000Z", count: 1 },
+        { periodStart: "2026-02-02T00:00:00.000Z", count: 2 },
+      ]);
+
+      expect(report.invocations.total).toBe(5);
+      expect(report.invocations.frequency).toEqual([
+        { periodStart: "2026-02-02T00:00:00.000Z", count: 3 },
+        { periodStart: "2026-02-09T00:00:00.000Z", count: 2 },
+      ]);
+
+      expect(report.parameterUsage).toEqual([
+        { parameter: "location", usedCount: 3, defaultUsedCount: 0, overriddenCount: 3 },
+        { parameter: "units", usedCount: 3, defaultUsedCount: 3, overriddenCount: 0 },
+        { parameter: "timezone", usedCount: 2, defaultUsedCount: 0, overriddenCount: 2 },
+      ]);
+    });
+  });
+
   describe("API handler", () => {
     it("returns skill listing from GET /skills", async () => {
       const marketplace = makeMarketplace();
@@ -114,6 +191,51 @@ describe("marketplace", () => {
       expect(payload.id).toBe("acme/weather");
     });
 
+    it("returns author analytics via API and dashboard", async () => {
+      const marketplace = makeMarketplace();
+      const analytics = new InMemoryMarketplaceSkillAnalytics(
+        marketplace,
+        () => new Date("2026-03-01T12:00:00.000Z"),
+      );
+      await analytics.recordInstall({
+        skillId: "acme/weather",
+        version: "1.2.0",
+        timestamp: "2026-02-02T01:00:00.000Z",
+      });
+      await analytics.recordInvocation({
+        skillId: "acme/weather",
+        invocationCount: 4,
+        parameters: { location: "Austin" },
+        timestamp: "2026-02-02T01:00:00.000Z",
+      });
+
+      const handler = createMarketplaceApiHandler({ marketplace, analytics });
+
+      const apiResponse = await handler({
+        method: "GET",
+        path: "/api/marketplace/authors/acme/analytics",
+        query: { interval: "daily" },
+      });
+
+      expect(apiResponse.status).toBe(200);
+      const payload = JSON.parse(apiResponse.body) as {
+        author: string;
+        invocations: { total: number };
+      };
+      expect(payload.author).toBe("acme");
+      expect(payload.invocations.total).toBe(4);
+
+      const dashboardResponse = await handler({
+        method: "GET",
+        path: "/api/marketplace/authors/acme/analytics/dashboard",
+      });
+
+      expect(dashboardResponse.status).toBe(200);
+      expect(dashboardResponse.headers["content-type"]).toContain("text/html");
+      expect(dashboardResponse.body).toContain("Skill Analytics · acme");
+      expect(dashboardResponse.body).toContain("Total invocations: 4");
+    });
+
     it("rejects unsupported methods", async () => {
       const marketplace = makeMarketplace();
       const handler = createMarketplaceApiHandler({ marketplace });
@@ -130,6 +252,27 @@ describe("marketplace", () => {
       expect(html).toContain("<h1>Skill Marketplace</h1>");
       expect(html).toContain("Weather Assistant");
       expect(html).toContain("Showing 2 of 3 skills.");
+    });
+
+    it("renders analytics dashboard page", async () => {
+      const marketplace = makeMarketplace();
+      const analytics = new InMemoryMarketplaceSkillAnalytics(
+        marketplace,
+        () => new Date("2026-03-01T12:00:00.000Z"),
+      );
+      await analytics.recordInstall({
+        skillId: "acme/weather",
+        version: "1.2.0",
+        timestamp: "2026-02-02T01:00:00.000Z",
+      });
+
+      const html = await renderMarketplaceAuthorAnalyticsPage({ marketplace, analytics }, "acme", {
+        interval: "monthly",
+      });
+
+      expect(html).toContain("Skill Analytics · acme");
+      expect(html).toContain("Installation counts");
+      expect(html).toContain("Per version");
     });
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -345,6 +345,34 @@ export {
   MemoryJobQueue,
 } from "./job-queue.js";
 export type {
+  AuthorSkillAnalytics,
+  AuthorSkillAnalyticsQuery,
+  MarketplaceApiOptions,
+  MarketplaceApiRequest,
+  MarketplaceApiResponse,
+  MarketplacePage,
+  MarketplaceQuery,
+  MarketplaceSkill,
+  MarketplaceSkillAnalytics,
+  MarketplaceSortBy,
+  MarketplaceSortOrder,
+  SkillAnalyticsInterval,
+  SkillInstallAnalyticsEvent,
+  SkillInvocationAnalyticsEvent,
+  SkillMarketplace,
+  SkillParameterUsagePattern,
+  SkillVersionInstallationCount,
+} from "./marketplace.js";
+export {
+  createMarketplaceApiHandler,
+  InMemoryMarketplaceSkillAnalytics,
+  InMemorySkillMarketplace,
+  renderMarketplaceAuthorAnalyticsHtml,
+  renderMarketplaceAuthorAnalyticsPage,
+  renderMarketplaceHtml,
+  renderMarketplacePage,
+} from "./marketplace.js";
+export type {
   McpPropagationOptions,
   McpPropagationReport,
   McpPropagationTarget,

--- a/packages/core/src/marketplace.ts
+++ b/packages/core/src/marketplace.ts
@@ -6,6 +6,7 @@ import type { SkillVisibility } from "./skill-schema.js";
 
 export type MarketplaceSortBy = "name" | "downloads" | "rating" | "updatedAt";
 export type MarketplaceSortOrder = "asc" | "desc";
+export type SkillAnalyticsInterval = "daily" | "weekly" | "monthly";
 
 export interface MarketplaceSkill {
   id: string;
@@ -98,6 +99,161 @@ export class InMemorySkillMarketplace implements SkillMarketplace {
   }
 }
 
+export interface SkillInstallAnalyticsEvent {
+  skillId: string;
+  version: string;
+  timestamp?: string;
+}
+
+export interface SkillInvocationAnalyticsEvent {
+  skillId: string;
+  version?: string;
+  invocationCount?: number;
+  parameters?: Record<string, unknown>;
+  defaultParameters?: string[];
+  timestamp?: string;
+}
+
+export interface SkillAnalyticsPoint {
+  periodStart: string;
+  count: number;
+}
+
+export interface SkillVersionInstallationCount {
+  version: string;
+  count: number;
+}
+
+export interface SkillParameterUsagePattern {
+  parameter: string;
+  usedCount: number;
+  defaultUsedCount: number;
+  overriddenCount: number;
+}
+
+export interface AuthorSkillAnalytics {
+  author: string;
+  interval: SkillAnalyticsInterval;
+  generatedAt: string;
+  installs: {
+    byVersion: SkillVersionInstallationCount[];
+    overTime: SkillAnalyticsPoint[];
+  };
+  invocations: {
+    total: number;
+    frequency: SkillAnalyticsPoint[];
+  };
+  parameterUsage: SkillParameterUsagePattern[];
+}
+
+export interface AuthorSkillAnalyticsQuery {
+  interval?: SkillAnalyticsInterval;
+  startTime?: Date;
+  endTime?: Date;
+}
+
+export interface MarketplaceSkillAnalytics {
+  recordInstall(event: SkillInstallAnalyticsEvent): Promise<void>;
+  recordInvocation(event: SkillInvocationAnalyticsEvent): Promise<void>;
+  getAuthorAnalytics(
+    author: string,
+    query?: AuthorSkillAnalyticsQuery,
+  ): Promise<AuthorSkillAnalytics>;
+}
+
+interface StoredInstallAnalyticsEvent {
+  skillId: string;
+  version: string;
+  timestamp: string;
+}
+
+interface StoredInvocationAnalyticsEvent {
+  skillId: string;
+  version: string | undefined;
+  invocationCount: number;
+  parameters: Record<string, unknown>;
+  defaultParameters: Set<string>;
+  timestamp: string;
+}
+
+export class InMemoryMarketplaceSkillAnalytics implements MarketplaceSkillAnalytics {
+  private readonly installs: StoredInstallAnalyticsEvent[] = [];
+  private readonly invocations: StoredInvocationAnalyticsEvent[] = [];
+
+  constructor(
+    private readonly marketplace: SkillMarketplace,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  async recordInstall(event: SkillInstallAnalyticsEvent): Promise<void> {
+    this.installs.push({
+      skillId: event.skillId,
+      version: event.version,
+      timestamp: event.timestamp ?? this.now().toISOString(),
+    });
+  }
+
+  async recordInvocation(event: SkillInvocationAnalyticsEvent): Promise<void> {
+    this.invocations.push({
+      skillId: event.skillId,
+      version: event.version,
+      invocationCount: Math.max(0, Math.floor(event.invocationCount ?? 1)),
+      parameters: event.parameters ?? {},
+      defaultParameters: new Set(event.defaultParameters ?? []),
+      timestamp: event.timestamp ?? this.now().toISOString(),
+    });
+  }
+
+  async getAuthorAnalytics(
+    author: string,
+    query: AuthorSkillAnalyticsQuery = {},
+  ): Promise<AuthorSkillAnalytics> {
+    const page = await this.marketplace.list({ limit: 1000, offset: 0 });
+    const authorSkillIds = new Set(
+      page.skills.filter((skill) => skill.author === author).map((skill) => skill.id),
+    );
+
+    const startMs = query.startTime?.getTime();
+    const endMs = query.endTime?.getTime();
+    const interval = query.interval ?? "daily";
+
+    const authorInstalls = this.installs.filter((event) => {
+      if (!authorSkillIds.has(event.skillId)) return false;
+      return withinRange(event.timestamp, startMs, endMs);
+    });
+
+    const authorInvocations = this.invocations.filter((event) => {
+      if (!authorSkillIds.has(event.skillId)) return false;
+      return withinRange(event.timestamp, startMs, endMs);
+    });
+
+    const installsByVersion = aggregateInstallationsByVersion(authorInstalls);
+    const installsOverTime = aggregateOverTime(authorInstalls, interval, (_event) => 1);
+    const invocationFrequency = aggregateOverTime(
+      authorInvocations,
+      interval,
+      (event) => event.invocationCount,
+    );
+
+    const parameterUsage = aggregateParameterUsage(authorInvocations);
+
+    return {
+      author,
+      interval,
+      generatedAt: this.now().toISOString(),
+      installs: {
+        byVersion: installsByVersion,
+        overTime: installsOverTime,
+      },
+      invocations: {
+        total: authorInvocations.reduce((sum, event) => sum + event.invocationCount, 0),
+        frequency: invocationFrequency,
+      },
+      parameterUsage,
+    };
+  }
+}
+
 export interface MarketplaceApiRequest {
   method: string;
   path: string;
@@ -112,6 +268,7 @@ export interface MarketplaceApiResponse {
 
 export interface MarketplaceApiOptions {
   marketplace: SkillMarketplace;
+  analytics?: MarketplaceSkillAnalytics;
   basePath?: string;
 }
 
@@ -138,6 +295,39 @@ export function createMarketplaceApiHandler(
       const skill = await options.marketplace.get(id);
       if (!skill) return json(404, { error: "not_found" });
       return json(200, skill);
+    }
+
+    const authorAnalyticsPrefix = `${basePath}/authors/`;
+    if (path.startsWith(authorAnalyticsPrefix) && path.endsWith("/analytics")) {
+      if (!options.analytics) return json(501, { error: "analytics_not_configured" });
+
+      const author = decodeURIComponent(
+        path.slice(authorAnalyticsPrefix.length, -"/analytics".length),
+      );
+      if (!author) return json(400, { error: "invalid_author" });
+
+      const analytics = await options.analytics.getAuthorAnalytics(
+        author,
+        parseAnalyticsQuery(request.query),
+      );
+      return json(200, analytics);
+    }
+
+    if (path.startsWith(authorAnalyticsPrefix) && path.endsWith("/analytics/dashboard")) {
+      if (!options.analytics) {
+        return json(501, { error: "analytics_not_configured" });
+      }
+
+      const author = decodeURIComponent(
+        path.slice(authorAnalyticsPrefix.length, -"/analytics/dashboard".length),
+      );
+      if (!author) return json(400, { error: "invalid_author" });
+
+      const analytics = await options.analytics.getAuthorAnalytics(
+        author,
+        parseAnalyticsQuery(request.query),
+      );
+      return html(200, renderMarketplaceAuthorAnalyticsHtml(analytics));
     }
 
     return json(404, { error: "not_found" });
@@ -182,8 +372,79 @@ export function renderMarketplaceHtml(page: MarketplacePage, title = "Skill Mark
 </html>`;
 }
 
+export function renderMarketplaceAuthorAnalyticsHtml(
+  analytics: AuthorSkillAnalytics,
+  title = `Skill Analytics · ${analytics.author}`,
+): string {
+  const installsByVersion =
+    analytics.installs.byVersion.length === 0
+      ? '<li class="empty">No installs yet.</li>'
+      : analytics.installs.byVersion
+          .map((point) => `<li><code>${escapeHtml(point.version)}</code>: ${point.count}</li>`)
+          .join("\n");
+
+  const frequency =
+    analytics.invocations.frequency.length === 0
+      ? '<li class="empty">No invocations yet.</li>'
+      : analytics.invocations.frequency
+          .map((point) => `<li>${escapeHtml(point.periodStart)}: ${point.count}</li>`)
+          .join("\n");
+
+  const params =
+    analytics.parameterUsage.length === 0
+      ? '<li class="empty">No parameter usage yet.</li>'
+      : analytics.parameterUsage
+          .map(
+            (entry) =>
+              `<li><code>${escapeHtml(entry.parameter)}</code> used ${entry.usedCount}x · default ${entry.defaultUsedCount}x · overridden ${entry.overriddenCount}x</li>`,
+          )
+          .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 900px; padding: 0 1rem; }
+    .section { border: 1px solid #ddd; border-radius: 12px; padding: 1rem; margin-bottom: 1rem; }
+    ul { margin: 0.5rem 0 0; }
+    .meta { color: #555; }
+    .empty { color: #666; }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  <p class="meta">Interval: ${escapeHtml(analytics.interval)} · Generated: ${escapeHtml(analytics.generatedAt)}</p>
+
+  <section class="section">
+    <h2>Installation counts</h2>
+    <h3>Per version</h3>
+    <ul>${installsByVersion}</ul>
+    <h3>Over time</h3>
+    <ul>${analytics.installs.overTime
+      .map((point) => `<li>${escapeHtml(point.periodStart)}: ${point.count}</li>`)
+      .join("\n")}</ul>
+  </section>
+
+  <section class="section">
+    <h2>Invocation frequency</h2>
+    <p>Total invocations: ${analytics.invocations.total}</p>
+    <ul>${frequency}</ul>
+  </section>
+
+  <section class="section">
+    <h2>Parameter usage patterns</h2>
+    <ul>${params}</ul>
+  </section>
+</body>
+</html>`;
+}
+
 export interface MarketplaceWebOptions {
   marketplace: SkillMarketplace;
+  analytics?: MarketplaceSkillAnalytics;
 }
 
 export async function renderMarketplacePage(
@@ -192,6 +453,16 @@ export async function renderMarketplacePage(
 ): Promise<string> {
   const page = await options.marketplace.list(query);
   return renderMarketplaceHtml(page);
+}
+
+export async function renderMarketplaceAuthorAnalyticsPage(
+  options: MarketplaceWebOptions,
+  author: string,
+  query: AuthorSkillAnalyticsQuery = {},
+): Promise<string> {
+  if (!options.analytics) throw new Error("Marketplace analytics not configured");
+  const analytics = await options.analytics.getAuthorAnalytics(author, query);
+  return renderMarketplaceAuthorAnalyticsHtml(analytics);
 }
 
 function clampInt(value: number, min: number, max: number): number {
@@ -225,31 +496,41 @@ function getSortValue(skill: MarketplaceSkill, sortBy: MarketplaceSortBy): numbe
   }
 }
 
-function parseQuery(query: Record<string, string | undefined>): MarketplaceQuery {
+interface MarketplaceListQueryParams {
+  search?: string;
+  tags?: string;
+  visibility?: string;
+  sortBy?: string;
+  sortOrder?: string;
+  limit?: string;
+  offset?: string;
+}
+
+function parseQuery(query: MarketplaceListQueryParams): MarketplaceQuery {
   const parsed: MarketplaceQuery = {};
 
-  const search = query["search"]?.trim();
+  const search = query.search?.trim();
   if (search) parsed.search = search;
 
-  const tags = query["tags"]
+  const tags = query.tags
     ?.split(",")
     .map((tag) => tag.trim())
     .filter(Boolean);
   if (tags && tags.length > 0) parsed.tags = tags;
 
-  const visibility = parseVisibility(query["visibility"]);
+  const visibility = parseVisibility(query.visibility);
   if (visibility) parsed.visibility = visibility;
 
-  const sortBy = parseSortBy(query["sortBy"]);
+  const sortBy = parseSortBy(query.sortBy);
   if (sortBy) parsed.sortBy = sortBy;
 
-  const sortOrder = parseSortOrder(query["sortOrder"]);
+  const sortOrder = parseSortOrder(query.sortOrder);
   if (sortOrder) parsed.sortOrder = sortOrder;
 
-  const limit = parseNullableInt(query["limit"]);
+  const limit = parseNullableInt(query.limit);
   if (limit !== undefined) parsed.limit = limit;
 
-  const offset = parseNullableInt(query["offset"]);
+  const offset = parseNullableInt(query.offset);
   if (offset !== undefined) parsed.offset = offset;
 
   return parsed;
@@ -285,6 +566,40 @@ function parseNullableInt(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+interface MarketplaceAnalyticsQueryParams {
+  interval?: string;
+  startTime?: string;
+  endTime?: string;
+}
+
+function parseAnalyticsQuery(
+  query: MarketplaceAnalyticsQueryParams = {},
+): AuthorSkillAnalyticsQuery {
+  const parsed: AuthorSkillAnalyticsQuery = {};
+
+  const interval = parseAnalyticsInterval(query.interval);
+  if (interval) parsed.interval = interval;
+
+  const startTime = parseDate(query.startTime);
+  if (startTime) parsed.startTime = startTime;
+
+  const endTime = parseDate(query.endTime);
+  if (endTime) parsed.endTime = endTime;
+
+  return parsed;
+}
+
+function parseAnalyticsInterval(value: string | undefined): SkillAnalyticsInterval | undefined {
+  if (value === "daily" || value === "weekly" || value === "monthly") return value;
+  return undefined;
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
 function stripQueryString(path: string): string {
   const q = path.indexOf("?");
   return q >= 0 ? path.slice(0, q) : path;
@@ -298,6 +613,14 @@ function json(status: number, payload: unknown): MarketplaceApiResponse {
   };
 }
 
+function html(status: number, payload: string): MarketplaceApiResponse {
+  return {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8" },
+    body: payload,
+  };
+}
+
 function escapeHtml(value: string): string {
   return value
     .replaceAll("&", "&amp;")
@@ -305,4 +628,88 @@ function escapeHtml(value: string): string {
     .replaceAll(">", "&gt;")
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&#39;");
+}
+
+function withinRange(timestamp: string, startMs?: number, endMs?: number): boolean {
+  const time = new Date(timestamp).getTime();
+  if (startMs !== undefined && time < startMs) return false;
+  if (endMs !== undefined && time >= endMs) return false;
+  return true;
+}
+
+function aggregateInstallationsByVersion(
+  events: StoredInstallAnalyticsEvent[],
+): SkillVersionInstallationCount[] {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    counts.set(event.version, (counts.get(event.version) ?? 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .map(([version, count]) => ({ version, count }))
+    .sort((a, b) => b.count - a.count || a.version.localeCompare(b.version));
+}
+
+function aggregateOverTime<T extends { timestamp: string }>(
+  events: T[],
+  interval: SkillAnalyticsInterval,
+  valueSelector: (event: T) => number,
+): SkillAnalyticsPoint[] {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    const key = periodStart(new Date(event.timestamp), interval);
+    counts.set(key, (counts.get(key) ?? 0) + valueSelector(event));
+  }
+
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([periodStartValue, count]) => ({ periodStart: periodStartValue, count }));
+}
+
+function aggregateParameterUsage(
+  events: StoredInvocationAnalyticsEvent[],
+): SkillParameterUsagePattern[] {
+  const usage = new Map<string, SkillParameterUsagePattern>();
+
+  for (const event of events) {
+    for (const parameter of Object.keys(event.parameters)) {
+      const current = usage.get(parameter) ?? {
+        parameter,
+        usedCount: 0,
+        defaultUsedCount: 0,
+        overriddenCount: 0,
+      };
+
+      current.usedCount += event.invocationCount;
+      if (event.defaultParameters.has(parameter)) {
+        current.defaultUsedCount += event.invocationCount;
+      } else {
+        current.overriddenCount += event.invocationCount;
+      }
+      usage.set(parameter, current);
+    }
+  }
+
+  return Array.from(usage.values()).sort(
+    (a, b) => b.usedCount - a.usedCount || a.parameter.localeCompare(b.parameter),
+  );
+}
+
+function periodStart(date: Date, interval: SkillAnalyticsInterval): string {
+  const year = date.getUTCFullYear();
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+
+  if (interval === "daily") {
+    return new Date(Date.UTC(year, month, day)).toISOString();
+  }
+
+  if (interval === "weekly") {
+    const midnight = Date.UTC(year, month, day);
+    const dayOfWeek = new Date(midnight).getUTCDay();
+    const delta = (dayOfWeek + 6) % 7;
+    return new Date(midnight - delta * 86_400_000).toISOString();
+  }
+
+  return new Date(Date.UTC(year, month, 1)).toISOString();
 }


### PR DESCRIPTION
## Summary
- add in-memory marketplace analytics service for marketplace-published skill authors
- aggregate installation counts per version and over time (daily/weekly/monthly)
- aggregate invocation frequency and parameter usage patterns (including default-vs-override counts)
- expose analytics via API endpoints and HTML dashboard rendering
- add/extend tests for analytics aggregation, API endpoints, and dashboard rendering

## Validation
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm lint` *(fails on pre-existing repository-wide Biome diagnostics unrelated to this PR)*

Closes #36
