### PR TITLE
feat(core): support project memory summarization pipeline (MEM-013)

### DIFF
--- a/packages/core/src/__tests__/memory-summarization.test.ts
+++ b/packages/core/src/__tests__/memory-summarization.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InMemoryMemoryStore } from "../memory-store.js";
+import { MemorySummarizationPipeline } from "../memory-summarization.js";
+
+describe("memory-summarization", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("summarizes old memories, references originals, and archives originals", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const context = { orgId: "org-1", projectId: "proj-1", sessionId: "sess-1" };
+
+    await store.write({
+      id: "old-1",
+      content: "Remember to rotate staging credentials every month.",
+      scope: "project",
+      context,
+      now: new Date("2026-02-01T00:00:00.000Z"),
+    });
+    await store.write({
+      id: "old-2",
+      content: "Deployment checklist includes smoke tests and rollback validation.",
+      scope: "project",
+      context,
+      now: new Date("2026-02-03T00:00:00.000Z"),
+    });
+
+    const pipeline = new MemorySummarizationPipeline(store, {
+      now: () => new Date("2026-03-01T00:00:00.000Z"),
+    });
+
+    pipeline.configureProject(
+      { orgId: "org-1", projectId: "proj-1" },
+      {
+        enabled: true,
+        scheduleMs: 60_000,
+        maxAgeMs: 7 * 24 * 60 * 60 * 1000,
+        minRecords: 2,
+      },
+    );
+
+    const result = await pipeline.runNow({ orgId: "org-1", projectId: "proj-1" });
+    expect(result.skipped).toBe(false);
+    expect(result.summarizedCount).toBe(2);
+
+    const projectMemories = await store.listByScope("project", context);
+    const summary = projectMemories.find((record) => record.id === result.summaryId);
+    const summaryMetadata = summary?.metadata as { originalMemoryIds?: string[] } | undefined;
+    expect(summary?.category).toBe("memory-summary");
+    expect(summaryMetadata?.originalMemoryIds).toEqual(["old-1", "old-2"]);
+
+    const archivedOne = await store.getById("old-1", context);
+    const archivedTwo = await store.getById("old-2", context);
+    const archivedOneMetadata = archivedOne?.metadata as
+      | { archived?: boolean; summaryId?: string }
+      | undefined;
+    const archivedTwoMetadata = archivedTwo?.metadata as { archived?: boolean } | undefined;
+    expect(archivedOneMetadata?.archived).toBe(true);
+    expect(archivedTwoMetadata?.archived).toBe(true);
+    expect(archivedOneMetadata?.summaryId).toBe(summary?.id);
+  });
+
+  it("supports per-project enable/disable configuration", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const context = { orgId: "org-1", projectId: "proj-2", sessionId: "sess-1" };
+    await store.write({
+      id: "old-1",
+      content: "An old memory",
+      scope: "project",
+      context,
+      now: new Date("2026-02-01T00:00:00.000Z"),
+    });
+
+    const pipeline = new MemorySummarizationPipeline(store, {
+      now: () => new Date("2026-03-01T00:00:00.000Z"),
+    });
+
+    pipeline.configureProject(
+      { orgId: "org-1", projectId: "proj-2" },
+      {
+        enabled: false,
+        scheduleMs: 60_000,
+        maxAgeMs: 24 * 60 * 60 * 1000,
+        minRecords: 1,
+      },
+    );
+
+    const result = await pipeline.runNow({ orgId: "org-1", projectId: "proj-2" });
+    expect(result.skipped).toBe(true);
+
+    const memories = await store.listByScope("project", context);
+    expect(memories).toHaveLength(1);
+  });
+
+  it("runs summarization on a configurable schedule", async () => {
+    const store = new InMemoryMemoryStore();
+    await store.init();
+
+    const context = { orgId: "org-1", projectId: "proj-3", sessionId: "sess-1" };
+    await store.write({
+      id: "old-1",
+      content: "first",
+      scope: "project",
+      context,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    const pipeline = new MemorySummarizationPipeline(store, {
+      now: () => new Date("2026-03-01T00:00:00.000Z"),
+    });
+
+    pipeline.configureProject(
+      { orgId: "org-1", projectId: "proj-3" },
+      {
+        enabled: true,
+        scheduleMs: 1_000,
+        maxAgeMs: 24 * 60 * 60 * 1000,
+        minRecords: 1,
+      },
+    );
+
+    pipeline.start();
+    await vi.advanceTimersByTimeAsync(1_100);
+    pipeline.stop();
+
+    const memories = await store.listByScope("project", context);
+    expect(memories.some((record) => record.category === "memory-summary")).toBe(true);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -492,6 +492,12 @@ export {
   SqlMemoryStore,
 } from "./memory-store.js";
 export type {
+  MemorySummarizationPipelineOptions,
+  MemorySummarizationProjectConfig,
+  MemorySummarizationRunResult,
+} from "./memory-summarization.js";
+export { MemorySummarizationPipeline } from "./memory-summarization.js";
+export type {
   ZepAddMemoryParams,
   ZepCompatibleMemoryClient,
   ZepContextResolver,

--- a/packages/core/src/memory-summarization.ts
+++ b/packages/core/src/memory-summarization.ts
@@ -1,0 +1,229 @@
+import type { MemoryContext, MemoryRecord, MemoryScope, MemoryStore } from "./memory-store.js";
+
+export interface MemorySummarizationProjectConfig {
+  enabled: boolean;
+  scheduleMs: number;
+  maxAgeMs: number;
+  minRecords?: number;
+  maxRecordsPerSummary?: number;
+  scopes?: MemoryScope[];
+}
+
+export interface MemorySummarizationPipelineOptions {
+  now?: () => Date;
+  summarySourceToolId?: string;
+  summarize?: (records: MemoryRecord[]) => string;
+}
+
+export interface MemorySummarizationRunResult {
+  orgId: string;
+  projectId: string;
+  summarizedCount: number;
+  archivedCount: number;
+  summaryId?: string;
+  skipped: boolean;
+}
+
+interface ProjectConfigEntry {
+  context: MemoryContext;
+  config: MemorySummarizationProjectConfig;
+  timer?: ReturnType<typeof setInterval>;
+}
+
+const DEFAULT_SCOPES: MemoryScope[] = ["project"];
+
+function projectKey(context: Pick<MemoryContext, "orgId" | "projectId">): string {
+  return `${context.orgId}::${context.projectId}`;
+}
+
+function defaultSummarize(records: MemoryRecord[]): string {
+  const lines = records.map((record) => {
+    const compactContent = record.content.replace(/\s+/g, " ").trim();
+    return `- [${record.id}] ${compactContent.slice(0, 240)}`;
+  });
+  return ["Archived memory summary", "", ...lines].join("\n");
+}
+
+export class MemorySummarizationPipeline {
+  private readonly projects = new Map<string, ProjectConfigEntry>();
+  private readonly now: () => Date;
+  private readonly summarySourceToolId: string;
+  private readonly summarize: (records: MemoryRecord[]) => string;
+
+  constructor(
+    private readonly store: MemoryStore,
+    options?: MemorySummarizationPipelineOptions,
+  ) {
+    this.now = options?.now ?? (() => new Date());
+    this.summarySourceToolId = options?.summarySourceToolId ?? "system:memory-summarizer";
+    this.summarize = options?.summarize ?? defaultSummarize;
+  }
+
+  configureProject(
+    context: Pick<MemoryContext, "orgId" | "projectId">,
+    config: MemorySummarizationProjectConfig,
+  ): void {
+    if (!context.projectId) {
+      throw new Error("Project memory summarization requires projectId");
+    }
+
+    if (config.scheduleMs <= 0) {
+      throw new Error("scheduleMs must be > 0");
+    }
+    if (config.maxAgeMs <= 0) {
+      throw new Error("maxAgeMs must be > 0");
+    }
+
+    const key = projectKey(context);
+    this.stopProjectByKey(key);
+    this.projects.set(key, {
+      context: { orgId: context.orgId, projectId: context.projectId },
+      config,
+    });
+
+    if (config.enabled) {
+      this.startProjectByKey(key);
+    }
+  }
+
+  removeProject(context: Pick<MemoryContext, "orgId" | "projectId">): void {
+    const key = projectKey(context);
+    this.stopProjectByKey(key);
+    this.projects.delete(key);
+  }
+
+  start(): void {
+    for (const key of this.projects.keys()) {
+      this.startProjectByKey(key);
+    }
+  }
+
+  stop(): void {
+    for (const key of this.projects.keys()) {
+      this.stopProjectByKey(key);
+    }
+  }
+
+  async runNow(
+    context: Pick<MemoryContext, "orgId" | "projectId">,
+  ): Promise<MemorySummarizationRunResult> {
+    if (!context.projectId) {
+      throw new Error("Project memory summarization requires projectId");
+    }
+
+    const key = projectKey(context);
+    const project = this.projects.get(key);
+    if (!project || !project.config.enabled) {
+      return {
+        orgId: context.orgId,
+        projectId: context.projectId,
+        summarizedCount: 0,
+        archivedCount: 0,
+        skipped: true,
+      };
+    }
+
+    const now = this.now();
+    const minCreatedAt = now.getTime() - project.config.maxAgeMs;
+    const scopes = project.config.scopes ?? DEFAULT_SCOPES;
+
+    const candidates = (
+      await Promise.all(
+        scopes.map((scope) => this.store.listByScope(scope, project.context, { now })),
+      )
+    )
+      .flat()
+      .filter((record) => !isArchivedRecord(record))
+      .filter((record) => new Date(record.createdAt).getTime() <= minCreatedAt)
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+    const minRecords = Math.max(1, project.config.minRecords ?? 3);
+    if (candidates.length < minRecords) {
+      return {
+        orgId: context.orgId,
+        projectId: context.projectId,
+        summarizedCount: 0,
+        archivedCount: 0,
+        skipped: true,
+      };
+    }
+
+    const summarizeCount = Math.max(1, project.config.maxRecordsPerSummary ?? candidates.length);
+    const recordsToSummarize = candidates.slice(0, summarizeCount);
+    const summaryContent = this.summarize(recordsToSummarize);
+    const summaryScope = recordsToSummarize[0]?.scope ?? "project";
+
+    const summary = await this.store.write({
+      content: summaryContent,
+      scope: summaryScope,
+      context: project.context,
+      category: "memory-summary",
+      sourceToolId: this.summarySourceToolId,
+      metadata: {
+        summarizedAt: now.toISOString(),
+        originalMemoryIds: recordsToSummarize.map((record) => record.id),
+      },
+      tags: ["summary", "archived"],
+      now,
+    });
+
+    for (const record of recordsToSummarize) {
+      const archiveContext: MemoryContext = {
+        orgId: record.orgId,
+        ...(record.projectId ? { projectId: record.projectId } : {}),
+        ...(record.sessionId ? { sessionId: record.sessionId } : {}),
+      };
+
+      await this.store.write({
+        id: record.id,
+        ...(record.key ? { key: record.key } : {}),
+        content: record.content,
+        scope: record.scope,
+        context: archiveContext,
+        ...(record.sourceToolId ? { sourceToolId: record.sourceToolId } : {}),
+        metadata: {
+          ...(record.metadata ?? {}),
+          archived: true,
+          archivedAt: now.toISOString(),
+          summaryId: summary.id,
+        },
+        ...(record.tags ? { tags: record.tags } : {}),
+        ...(record.category ? { category: record.category } : {}),
+        now,
+      });
+    }
+
+    return {
+      orgId: context.orgId,
+      projectId: context.projectId,
+      summarizedCount: recordsToSummarize.length,
+      archivedCount: recordsToSummarize.length,
+      summaryId: summary.id,
+      skipped: false,
+    };
+  }
+
+  private startProjectByKey(key: string): void {
+    const project = this.projects.get(key);
+    if (!project || !project.config.enabled || project.timer) {
+      return;
+    }
+
+    project.timer = setInterval(() => {
+      void this.runNow(project.context);
+    }, project.config.scheduleMs);
+  }
+
+  private stopProjectByKey(key: string): void {
+    const project = this.projects.get(key);
+    if (project?.timer) {
+      clearInterval(project.timer);
+      delete project.timer;
+    }
+  }
+}
+
+function isArchivedRecord(record: MemoryRecord): boolean {
+  const metadata = record.metadata as { archived?: boolean } | undefined;
+  return metadata?.archived === true;
+}


### PR DESCRIPTION
## Summary\n- add a memory summarization pipeline with per-project enable/disable configuration\n- support scheduled summarization runs with configurable interval/age thresholds\n- generate compact summary memories that reference original memory IDs\n- archive (not delete) summarized originals with archive metadata and summary linkage\n- add end-to-end tests covering schedule, archiving behavior, and per-project config\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n- pnpm test:run\n\nCloses #51