### PR TITLE
feat(memory): add relevance decay scoring for semantic retrieval (MEM-014)

### DIFF
--- a/docs/memory-semantic-retrieval.md
+++ b/docs/memory-semantic-retrieval.md
@@ -6,8 +6,9 @@
 
 - Memories are embedded at write time
 - Embedding model is configurable (`defaultEmbeddingModel` + per-write override)
-- Retrieval ranks results by cosine similarity
+- Retrieval ranks results by cosine similarity with configurable relevance decay
 - Top-K results are supported (`k`, default `10`)
+- Decay rate is configurable via half-life in days (`relevanceHalfLifeDays`)
 - Optional filtered retrieval by memory `tags` and `category`
 
 ## API
@@ -16,7 +17,7 @@ See `packages/core/src/memory-store.ts`:
 
 - `MemoryEmbeddingProvider`
 - `MemoryStore#semanticSearch(query, scope, context, options)`
-- `MemorySearchOptions` (`k`, `embeddingModel`, scope visibility options, retrieval `filter`)
+- `MemorySearchOptions` (`k`, `embeddingModel`, `relevanceHalfLifeDays`, scope visibility options, retrieval `filter`)
 - `MemorySearchResult` (`memory`, `score`)
 
 ## Example

--- a/packages/core/src/__tests__/memory-store.semantic.test.ts
+++ b/packages/core/src/__tests__/memory-store.semantic.test.ts
@@ -142,6 +142,76 @@ describe("memory-store semantic retrieval", () => {
     expect(topThree).toHaveLength(3);
   });
 
+  it("applies relevance decay using lastAccessedAt and boosts recent memories", async () => {
+    const provider = new KeywordEmbeddingProvider(["deploy"]);
+    const store = createSemanticMemoryStore({
+      embeddingProvider: provider,
+      relevanceHalfLifeDays: 7,
+    });
+    const now = new Date("2026-03-05T12:00:00.000Z");
+
+    await store.writeBatch([
+      {
+        id: "recent",
+        content: "deploy",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        metadata: { lastAccessedAt: "2026-03-04T12:00:00.000Z" },
+      },
+      {
+        id: "stale",
+        content: "deploy",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        metadata: { lastAccessedAt: "2026-02-03T12:00:00.000Z" },
+      },
+    ]);
+
+    const results = await store.semanticSearch("deploy", "project", PROJECT_CONTEXT, { now, k: 2 });
+
+    expect(results[0]?.memory.id).toBe("recent");
+    expect(results[0]?.score).toBeGreaterThan(results[1]?.score ?? 0);
+  });
+
+  it("supports configurable decay half-life in days", async () => {
+    const provider = new KeywordEmbeddingProvider(["deploy"]);
+    const store = createSemanticMemoryStore({ embeddingProvider: provider });
+    const now = new Date("2026-03-05T12:00:00.000Z");
+
+    await store.writeBatch([
+      {
+        id: "fresh",
+        content: "deploy",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        metadata: { lastAccessedAt: "2026-03-04T12:00:00.000Z" },
+      },
+      {
+        id: "aging",
+        content: "deploy",
+        scope: "project",
+        context: PROJECT_CONTEXT,
+        metadata: { lastAccessedAt: "2026-02-19T12:00:00.000Z" },
+      },
+    ]);
+
+    const fastDecay = await store.semanticSearch("deploy", "project", PROJECT_CONTEXT, {
+      now,
+      k: 2,
+      relevanceHalfLifeDays: 3,
+    });
+    const slowDecay = await store.semanticSearch("deploy", "project", PROJECT_CONTEXT, {
+      now,
+      k: 2,
+      relevanceHalfLifeDays: 30,
+    });
+
+    const fastGap = (fastDecay[0]?.score ?? 0) - (fastDecay[1]?.score ?? 0);
+    const slowGap = (slowDecay[0]?.score ?? 0) - (slowDecay[1]?.score ?? 0);
+
+    expect(fastGap).toBeGreaterThan(slowGap);
+  });
+
   it("keeps p95 search latency under 500ms for typical batch size", async () => {
     const provider = new KeywordEmbeddingProvider([
       "deploy",
@@ -194,6 +264,6 @@ describe("cosineSimilarity", () => {
 
   it("computes expected similarity", () => {
     const score = cosineSimilarity([1, 1], [1, 0]);
-    expect(score).toBeCloseTo(0.7071, 3);
+    expect(score).toBeCloseTo(Math.SQRT1_2, 3);
   });
 });

--- a/packages/core/src/memory-store.ts
+++ b/packages/core/src/memory-store.ts
@@ -94,6 +94,7 @@ export interface MemorySearchOptions {
   now?: Date;
   k?: number;
   embeddingModel?: string;
+  relevanceHalfLifeDays?: number;
   filter?: MemoryRetrievalFilter;
 }
 
@@ -174,6 +175,7 @@ export interface MemoryStore {
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_TOP_K = 10;
 const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
+const DEFAULT_RELEVANCE_HALF_LIFE_DAYS = 30;
 const DEFAULT_AUDIT_ACTOR = "system:memory-store";
 
 function randomId(): string {
@@ -351,6 +353,10 @@ export interface MemoryStoreRuntimeOptions {
   embeddingProvider?: MemoryEmbeddingProvider;
   defaultEmbeddingModel?: string;
   defaultTopK?: number;
+  /**
+   * Relevance half-life in days for semantic search decay. Lower values increase decay speed.
+   */
+  relevanceHalfLifeDays?: number;
   conflictResolutionStrategy?: MemoryConflictResolutionStrategy;
   conflictResolutionByProject?: (
     context: MemoryContext,
@@ -382,6 +388,26 @@ export function cosineSimilarity(a: number[], b: number[]): number {
   }
   if (normA === 0 || normB === 0) return 0;
   return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function getLastAccessedAt(record: MemoryRecord): Date {
+  const metadataValue = record.metadata?.["lastAccessedAt"];
+  if (typeof metadataValue === "string") {
+    const parsed = new Date(metadataValue);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  const created = new Date(record.createdAt);
+  return Number.isNaN(created.getTime()) ? new Date(0) : created;
+}
+
+function relevanceDecayMultiplier(record: MemoryRecord, now: Date, halfLifeDays: number): number {
+  const safeHalfLifeDays = Number.isFinite(halfLifeDays) ? Math.max(0.01, halfLifeDays) : 0.01;
+  const ageMs = Math.max(0, now.getTime() - getLastAccessedAt(record).getTime());
+  const ageDays = ageMs / (24 * 60 * 60 * 1000);
+  return 0.5 ** (ageDays / safeHalfLifeDays);
 }
 
 interface MemoryAuditEvent {
@@ -422,6 +448,7 @@ export class InMemoryMemoryStore implements MemoryStore {
   private embeddingProvider: MemoryEmbeddingProvider;
   private defaultEmbeddingModel: string;
   private defaultTopK: number;
+  private relevanceHalfLifeDays: number;
   private conflictResolutionStrategy: MemoryConflictResolutionStrategy;
   private conflictResolutionByProject:
     | ((context: MemoryContext) => MemoryConflictResolutionStrategy | undefined)
@@ -432,6 +459,7 @@ export class InMemoryMemoryStore implements MemoryStore {
     this.embeddingProvider = options?.embeddingProvider ?? new DefaultMemoryEmbeddingProvider();
     this.defaultEmbeddingModel = options?.defaultEmbeddingModel ?? DEFAULT_EMBEDDING_MODEL;
     this.defaultTopK = Math.max(1, options?.defaultTopK ?? DEFAULT_TOP_K);
+    this.relevanceHalfLifeDays = options?.relevanceHalfLifeDays ?? DEFAULT_RELEVANCE_HALF_LIFE_DAYS;
     this.conflictResolutionStrategy = options?.conflictResolutionStrategy ?? "last-write-wins";
     this.conflictResolutionByProject = options?.conflictResolutionByProject;
     this.auditLogger = new MemoryAuditLogger(options?.auditStorage, options?.auditActor);
@@ -833,16 +861,21 @@ export class InMemoryMemoryStore implements MemoryStore {
     const k = Math.max(1, options?.k ?? this.defaultTopK);
     const model = options?.embeddingModel ?? this.defaultEmbeddingModel;
     const filter = options?.filter;
+    const halfLifeDays = options?.relevanceHalfLifeDays ?? this.relevanceHalfLifeDays;
     const queryEmbedding = await this.embeddingProvider.embed(query, { model });
 
     return Array.from(this.records.values())
       .filter((record) => !isExpired(record, now))
       .filter((record) => canRead(record, scope, context, includeShared))
       .filter((record) => matchesFilter(record, filter))
-      .map((memory) => ({
-        memory,
-        score: cosineSimilarity(queryEmbedding, memory.embedding ?? []),
-      }))
+      .map((memory) => {
+        const similarity = cosineSimilarity(queryEmbedding, memory.embedding ?? []);
+        const decay = relevanceDecayMultiplier(memory, now, halfLifeDays);
+        return {
+          memory,
+          score: similarity * decay,
+        };
+      })
       .sort((a, b) => b.score - a.score)
       .slice(0, k);
   }
@@ -929,6 +962,7 @@ export class SqlMemoryStore implements MemoryStore {
   private embeddingProvider: MemoryEmbeddingProvider;
   private defaultEmbeddingModel: string;
   private defaultTopK: number;
+  private relevanceHalfLifeDays: number;
   private conflictResolutionStrategy: MemoryConflictResolutionStrategy;
   private conflictResolutionByProject:
     | ((context: MemoryContext) => MemoryConflictResolutionStrategy | undefined)
@@ -942,6 +976,7 @@ export class SqlMemoryStore implements MemoryStore {
     this.embeddingProvider = options?.embeddingProvider ?? new DefaultMemoryEmbeddingProvider();
     this.defaultEmbeddingModel = options?.defaultEmbeddingModel ?? DEFAULT_EMBEDDING_MODEL;
     this.defaultTopK = Math.max(1, options?.defaultTopK ?? DEFAULT_TOP_K);
+    this.relevanceHalfLifeDays = options?.relevanceHalfLifeDays ?? DEFAULT_RELEVANCE_HALF_LIFE_DAYS;
     this.conflictResolutionStrategy = options?.conflictResolutionStrategy ?? "last-write-wins";
     this.conflictResolutionByProject = options?.conflictResolutionByProject;
     this.auditLogger = new MemoryAuditLogger(options?.auditStorage, options?.auditActor);
@@ -1519,14 +1554,20 @@ export class SqlMemoryStore implements MemoryStore {
   ): Promise<MemorySearchResult[]> {
     const k = Math.max(1, options?.k ?? this.defaultTopK);
     const model = options?.embeddingModel ?? this.defaultEmbeddingModel;
+    const now = options?.now ?? new Date();
+    const halfLifeDays = options?.relevanceHalfLifeDays ?? this.relevanceHalfLifeDays;
     const queryEmbedding = await this.embeddingProvider.embed(query, { model });
     const visible = await this.listByScope(scope, context, options);
 
     return visible
-      .map((memory) => ({
-        memory,
-        score: cosineSimilarity(queryEmbedding, memory.embedding ?? []),
-      }))
+      .map((memory) => {
+        const similarity = cosineSimilarity(queryEmbedding, memory.embedding ?? []);
+        const decay = relevanceDecayMultiplier(memory, now, halfLifeDays);
+        return {
+          memory,
+          score: similarity * decay,
+        };
+      })
       .sort((a, b) => b.score - a.score)
       .slice(0, k);
   }


### PR DESCRIPTION
## Summary
- apply time-decay multiplier to semantic similarity scoring based on memory recency
- make decay configurable via `relevanceHalfLifeDays` (runtime default + per-search override)
- use `metadata.lastAccessedAt` (fallback: `createdAt`) to boost recently accessed memories over stale ones
- add semantic retrieval tests for recency boost and configurable half-life
- update semantic retrieval docs

## Validation
- `pnpm test:run packages/core/src/__tests__/memory-store.semantic.test.ts`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm lint` *(fails on pre-existing repo-wide Biome warnings unrelated to this PR)*

Closes #52
