### PR TITLE
feat: support handoff templates in canonical config and CLI

### DIFF
--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -38,6 +38,14 @@ const { values: flags, positionals } = parseArgs({
     "teams-dir": { type: "string" },
     format: { type: "string", short: "f" },
     output: { type: "string" },
+    template: { type: "string" },
+    include: { type: "string" },
+    routing: { type: "string" },
+    constraints: { type: "string" },
+    mode: { type: "string" },
+    timeout: { type: "string" },
+    "permission-allow": { type: "string" },
+    "permission-deny": { type: "string" },
     help: { type: "boolean", short: "h", default: false },
   },
   allowPositionals: true,
@@ -63,6 +71,7 @@ Commands:
   sync      Sync canonical instruction file to tool-specific output files
   validate  Validate a canonical instruction file against the ADR-001 schema
   import    Import a tool-specific file to canonical format (CONF-013)
+  handoff   Resolve and render a named handoff template from canonical config (HAND-011)
 
 Options for sync:
   --source, -s       Path to canonical instruction file (required)
@@ -86,6 +95,17 @@ Options for import:
   --source, -s      Path to tool-specific file (required)
   --format, -f      Source format (auto-detected if not specified)
   --output          Output path for canonical file (default: stdout)
+
+Options for handoff:
+  --source, -s            Path to canonical instruction file (required)
+  --template              Named handoff template from frontmatter.handoff.templates (required)
+  --include               Comma-separated field paths override for includedFields
+  --routing               Override routing policy
+  --constraints           Comma-separated default constraints override
+  --permission-allow      Comma-separated permission allow list override
+  --permission-deny       Comma-separated permission deny list override
+  --mode                  Optional handoff mode override (sync|async)
+  --timeout               Optional timeout override in seconds
 
 Supported import formats: ${IMPORT_FORMATS.join(", ")}
 Registered adapters: ${ALL_ADAPTERS.map((a) => a.toolId).join(", ")}`);
@@ -278,6 +298,80 @@ if (command === "sync") {
   }
 
   process.exit(hasError ? 1 : 0);
+}
+
+if (command === "handoff") {
+  const source = flags.source;
+  const templateName = flags.template;
+  if (!source) {
+    console.error("Error: --source is required for handoff");
+    process.exit(1);
+  }
+  if (!templateName) {
+    console.error("Error: --template is required for handoff");
+    process.exit(1);
+  }
+
+  const csv = (input?: string): string[] | undefined => {
+    if (!input) return undefined;
+    return input
+      .split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  };
+
+  try {
+    const doc = parseCanonical(resolve(source));
+    const handoff = (
+      doc.frontmatter as {
+        handoff?: {
+          templates?: Record<
+            string,
+            {
+              version: string;
+              includedFields: string[];
+              routingPolicy: string;
+              permissionScope: { allow: string[]; deny: string[] };
+              defaultConstraints: string[];
+            }
+          >;
+        };
+      }
+    ).handoff;
+
+    const template = handoff?.templates?.[templateName];
+    if (!template) {
+      const available = Object.keys(handoff?.templates ?? {});
+      const hint = available.length > 0 ? ` Available templates: ${available.join(", ")}` : "";
+      throw new Error(`Unknown handoff template '${templateName}'.${hint}`);
+    }
+
+    const timeoutOverride = flags.timeout ? Number.parseInt(flags.timeout, 10) : undefined;
+    if (flags.timeout && Number.isNaN(timeoutOverride)) {
+      throw new Error("--timeout must be a number");
+    }
+
+    const resolved = {
+      name: templateName,
+      version: template.version,
+      includedFields: csv(flags.include) ?? template.includedFields,
+      routingPolicy: flags.routing ?? template.routingPolicy,
+      permissionScope: {
+        allow: csv(flags["permission-allow"]) ?? template.permissionScope.allow,
+        deny: csv(flags["permission-deny"]) ?? template.permissionScope.deny,
+      },
+      defaultConstraints: csv(flags.constraints) ?? template.defaultConstraints,
+      ...(flags.mode ? { mode: flags.mode } : {}),
+      ...(timeoutOverride !== undefined ? { timeoutSeconds: timeoutOverride } : {}),
+    };
+
+    console.log(JSON.stringify(resolved, null, 2));
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  process.exit(0);
 }
 
 if (command === "import") {

--- a/packages/core/src/__tests__/handoff-template-config.test.ts
+++ b/packages/core/src/__tests__/handoff-template-config.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { parseCanonicalString } from "../parse.js";
+import { mergeScopes } from "../scope.js";
+
+describe("handoff template config (HAND-011)", () => {
+  it("parses named handoff templates from YAML frontmatter", () => {
+    const doc = parseCanonicalString(`---
+version: "1.0"
+scope: team
+handoff:
+  templates:
+    code-review:
+      version: "1.0.0"
+      includedFields:
+        - task
+        - workingContext.openFiles
+      routingPolicy: capability-match
+      permissionScope:
+        allow: ["read", "comment"]
+        deny: ["delete"]
+      defaultConstraints:
+        - no-force-push
+---
+
+# Team config
+`);
+
+    expect(doc.frontmatter.handoff?.templates["code-review"]).toEqual({
+      version: "1.0.0",
+      includedFields: ["task", "workingContext.openFiles"],
+      routingPolicy: "capability-match",
+      permissionScope: {
+        allow: ["read", "comment"],
+        deny: ["delete"],
+      },
+      defaultConstraints: ["no-force-push"],
+    });
+  });
+
+  it("merges templates by name across scopes, preferring higher precedence", () => {
+    const merged = mergeScopes([
+      {
+        scope: "org",
+        path: "org.md",
+        document: parseCanonicalString(`---
+version: "1.0"
+scope: org
+handoff:
+  templates:
+    triage:
+      version: "1.0.0"
+      includedFields: ["task"]
+      routingPolicy: round-robin
+      permissionScope:
+        allow: ["read"]
+        deny: []
+      defaultConstraints: ["org-constraint"]
+---
+
+Org`),
+      },
+      {
+        scope: "team",
+        path: "team.md",
+        document: parseCanonicalString(`---
+version: "1.0"
+scope: team
+handoff:
+  templates:
+    triage:
+      version: "1.1.0"
+      includedFields: ["task", "conversationSummary"]
+      routingPolicy: least-loaded
+      permissionScope:
+        allow: ["read", "write"]
+        deny: []
+      defaultConstraints: ["team-constraint"]
+    incident:
+      version: "1.0.0"
+      includedFields: ["task", "constraints"]
+      routingPolicy: direct
+      permissionScope:
+        allow: ["read"]
+        deny: ["delete"]
+      defaultConstraints: ["urgent"]
+---
+
+Team`),
+      },
+    ]);
+
+    expect(merged.frontmatter.handoff?.templates["triage"]?.version).toBe("1.1.0");
+    expect(merged.frontmatter.handoff?.templates["incident"]?.version).toBe("1.0.0");
+  });
+});

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -82,6 +82,23 @@ export const ToolOverridesSchema = z.looseObject({
 
 // ─── Frontmatter schema (ADR-001 §7.2) ───────────────────────────────────────
 
+const HandoffTemplateConfigSchema = z.object({
+  version: z.string().regex(/^\d+\.\d+\.\d+$/, "template version must match semver N.N.N"),
+  includedFields: z.array(z.string()).default([]),
+  routingPolicy: z.enum(["direct", "round-robin", "least-loaded", "capability-match"]),
+  permissionScope: z
+    .object({
+      allow: z.array(z.string()).default([]),
+      deny: z.array(z.string()).default([]),
+    })
+    .default({ allow: [], deny: [] }),
+  defaultConstraints: z.array(z.string()).default([]),
+});
+
+const HandoffConfigSchema = z.object({
+  templates: z.record(z.string(), HandoffTemplateConfigSchema).default({}),
+});
+
 export const FrontmatterSchema = z.object({
   version: z
     .string()
@@ -107,6 +124,7 @@ export const FrontmatterSchema = z.object({
       allowedTools: z.array(z.string()).optional(),
     })
     .optional(),
+  handoff: HandoffConfigSchema.optional(),
 });
 
 // ─── Top-level canonical document schema ─────────────────────────────────────

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -115,6 +115,16 @@ function mergeFrontmatter(base: Frontmatter, override: Frontmatter): Frontmatter
     result.permissions = { ...base.permissions, ...override.permissions };
   }
 
+  // Handoff templates: merge by template name, higher-precedence replaces lower.
+  if (override.handoff) {
+    result.handoff = {
+      templates: {
+        ...(base.handoff?.templates ?? {}),
+        ...(override.handoff.templates ?? {}),
+      },
+    };
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary
- add HAND-011 handoff template support to canonical YAML frontmatter (`frontmatter.handoff.templates`)
- support template fields for included fields, routing policy, permission scope, default constraints, and semantic template version
- merge handoff templates across org/team/project scopes in CONF-004 precedence order
- add `laup handoff --template <name>` command support to resolve templates by name
- add tests for parsing and scoped merge behavior

## Validation
- pnpm test:run
- pnpm typecheck
- pnpm lint

Closes #84
