### PR TITLE
[MIG-001] Baseline Lock Before Enforcement

### DIFF
--- a/docs/quality-baseline.md
+++ b/docs/quality-baseline.md
@@ -13,6 +13,14 @@ The baseline contains:
 - `flakyTests`
 - `coverageByPackage` (`lines`, `statements`, `functions`, `branches`)
 
+## Committed Baseline
+
+The current quality baseline is committed to the repository and can be viewed at:
+
+**[quality/baseline.v1.json](../quality/baseline.v1.json)**
+
+This baseline is locked as part of MIG-001 (Baseline Lock Before Enforcement) and serves as the reference point for quality metrics tracking and enforcement.
+
 ## Determinism
 
 For the same repository content and commit SHA, baseline output is stable:

--- a/quality/baseline.v1.json
+++ b/quality/baseline.v1.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "1.0.0",
-  "commitSha": "6fa8a80c3dce6f3d1c53d033b442d212f87b2da9",
-  "generationTimestamp": "2026-03-05T08:23:41-06:00",
+  "commitSha": "057cdd61525ec15b9f623c96f7a8f2412e548fc4",
+  "generationTimestamp": "2026-03-07T01:28:40-06:00",
   "lintDiagnosticsBySeverity": {
     "error": 0,
     "warning": 0,
@@ -78,14 +78,14 @@
     },
     "core": {
       "lines": {
-        "covered": 4859,
-        "total": 6058,
-        "pct": 80.21
+        "covered": 4862,
+        "total": 6062,
+        "pct": 80.2
       },
       "statements": {
-        "covered": 5160,
-        "total": 6609,
-        "pct": 78.08
+        "covered": 5163,
+        "total": 6613,
+        "pct": 78.07
       },
       "functions": {
         "covered": 1133,
@@ -93,9 +93,9 @@
         "pct": 82.46
       },
       "branches": {
-        "covered": 3305,
-        "total": 5208,
-        "pct": 63.46
+        "covered": 3295,
+        "total": 5198,
+        "pct": 63.39
       }
     }
   }


### PR DESCRIPTION
## Summary
Implements MIG-001: Lock quality baseline before enforcement migration.

## Changes
- Generated and committed quality baseline to `quality/baseline.v1.json`
- Updated `docs/quality-baseline.md` (DOC-601) to reference the committed baseline

## Baseline Metrics
- **Lint diagnostics:** 0 errors, 0 warnings, 0 info
- **Tests:** 0 skipped, 0 flaky
- **Coverage by package:**
  - adapters: 96.9% lines
  - cli: 0% lines (no tests)
  - config-hub: 57.49% lines
  - core: 80.2% lines

## Acceptance Criteria
- [x] Baseline generated (verified through multiple runs)
- [x] Baseline committed and linked from DOC-601

## Testing
- Baseline generation tested multiple times to verify determinism
- All pre-push quality gates passed
- Documentation links verified

Closes #264